### PR TITLE
feat/page-main-concert: 메인 공연페이지 필터 버그 고침 및 디자인 수정

### DIFF
--- a/src/components/mainConcert/ConertListSection/ConcertListSection.module.css
+++ b/src/components/mainConcert/ConertListSection/ConcertListSection.module.css
@@ -4,6 +4,6 @@
 .concert-list {
   padding-top: 10px;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(21.25rem, 1fr));
-  gap: 2.5rem 1.25rem;
+  grid-template-columns: repeat(auto-fill, minmax(18.4375rem, 1fr));
+  gap: 2.5rem;
 }

--- a/src/components/mainConcert/ConertListSection/ConcertListSection.tsx
+++ b/src/components/mainConcert/ConertListSection/ConcertListSection.tsx
@@ -12,7 +12,7 @@ const ConcertListSection: React.FC<PropsType> = ({ filterRequest }) => {
   const { start_date, end_date, location, category, progress } = filterRequest;
   const { data, status, error } = useQuery({
     queryKey: ["concertData", filterRequest],
-    queryFn: async () => await getShows("concert", start_date, end_date, location, category, progress),
+    queryFn: async () => await getShows("concert", start_date, end_date, location, progress, category),
   });
 
   if (status === "pending") return <>loading...</>;

--- a/src/components/mainConcert/TicketCard/TicketCard.module.css
+++ b/src/components/mainConcert/TicketCard/TicketCard.module.css
@@ -70,7 +70,7 @@
   margin: 0;
 }
 
-@media (max-width: 760px) {
+@media (max-width: 689.5px) {
   .card__info h3 {
     font-size: 3vw;
   }

--- a/src/components/mainConcert/TicketCard/TicketCard.tsx
+++ b/src/components/mainConcert/TicketCard/TicketCard.tsx
@@ -15,7 +15,7 @@ const TicketCard: React.FC<PropsType> = ({ item }) => {
 
   return (
     <article className={styles.card} style={{ backgroundColor }}>
-      <Link to={`detail/${item.id}`}>
+      <Link to={`/detail/${item.id}`}>
         <div className={styles["card__img-wrapper"]}>
           <img src={`${import.meta.env.VITE_APP_IMAGE_DOMAIN}${item.main_image_url}`} alt="" />
         </div>


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [ ] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 : 
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

- getShows함수 params순서가 progress, category순으로 넣도록 기존에 바꿨었는데, getShows함수를 호출하는 부분에서는 바꾸지 않아 에러가 났습니다. 호출하는 부분에서 params순서를 progress, category순으로 바꿨습니다.
- TicketCard 컴포넌트 390에서 양옆 간격이 서로 안맞아서 수정했습니다.
- 390에서 양옆간격 안맞는 모습입니다 (background: pink 준 이유는 양옆간격 잘 보이라고 줘봤습니다)
<img width="185" alt="image" src="https://github.com/FESP-TEAM-1/beta-frontend/assets/75666099/40a33092-a13c-4b75-8f08-fe56f83736e0">

- 360까지 대응해봤습니다!
<img width="165" alt="image" src="https://github.com/FESP-TEAM-1/beta-frontend/assets/75666099/1d1bfca8-97fa-49b5-93c1-bdc2bd449654">

<br>

## 🌟 전달 사항
- 빠른 승인 부탁드립니다 :) getShows함수 버그 때문에(ㅎㅎ)


<br>

## ⚠️ Issue Number

- #20 

<br><br>
