### PR TITLE
feat/page-login : 로그인 API 적용 및 토큰 검증 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,15 @@
 import { Outlet, useLocation } from "react-router-dom";
 import { Header } from "./components/layouts";
+import PrivateRoute from "./PrivateRoute";
 
 function App() {
   const location = useLocation();
+
+  const isPrivateRoute = location.pathname.startsWith("/mypage");
   return (
     <>
       {location.pathname !== "/signup" && location.pathname !== "/login" && <Header />}
-      <Outlet />
+      {isPrivateRoute ? <PrivateRoute /> : <Outlet />}
     </>
   );
 }

--- a/src/PrivateRoute.tsx
+++ b/src/PrivateRoute.tsx
@@ -1,19 +1,26 @@
+import { useState } from "react";
 import { Navigate, useLocation, Outlet } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
-import { verifyToken } from "@/apis/getVerifyToken";
+import useAuth from "@/hooks/useAuth";
+
+interface PropsType {
+  isLogin: boolean;
+  login_id: string;
+  user_name: string;
+  user_role: string;
+}
 
 const PrivateRoute = () => {
   const location = useLocation();
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+  const [data, setData] = useState<null | PropsType>(null);
 
-  const { data, status, error } = useQuery({
-    queryKey: ["verifyTokenData"],
-    queryFn: () => verifyToken(),
-  });
+  useAuth(setIsLoading, setData, setIsError);
 
-  if (status === "pending") return <h1>loading...</h1>;
-  if (status === "error") return <h1>{error.message}</h1>;
+  if (isLoading) return <div>로딩중...</div>;
+  if (isError) return <div>error</div>;
 
-  return data ? <Outlet /> : <Navigate to="/login" state={{ from: location }} replace />;
+  return data?.isLogin ? <Outlet /> : <Navigate to="/login" state={{ from: location }} replace />;
 };
 
 export default PrivateRoute;

--- a/src/PrivateRoute.tsx
+++ b/src/PrivateRoute.tsx
@@ -1,0 +1,19 @@
+import { Navigate, useLocation, Outlet } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { verifyToken } from "@/apis/getVerifyToken";
+
+const PrivateRoute = () => {
+  const location = useLocation();
+
+  const { data, status, error } = useQuery({
+    queryKey: ["verifyTokenData"],
+    queryFn: () => verifyToken(),
+  });
+
+  if (status === "pending") return <h1>loading...</h1>;
+  if (status === "error") return <h1>{error.message}</h1>;
+
+  return data ? <Outlet /> : <Navigate to="/login" state={{ from: location }} replace />;
+};
+
+export default PrivateRoute;

--- a/src/apis/getVerifyToken.tsx
+++ b/src/apis/getVerifyToken.tsx
@@ -1,0 +1,29 @@
+import axios, { AxiosError } from "axios";
+
+export const verifyToken = async () => {
+  try {
+    await axios.get("/api/verifyToken");
+    console.log("Access token is valid");
+    return true;
+  } catch (error) {
+    // accessToken이 만료된 경우
+    const axiosError = error as AxiosError;
+    console.log("Access token is Invalid");
+
+    if (axiosError.response && axiosError.response.status === 401) {
+      try {
+        await axios.get("/api/refreshToken");
+        console.log("refresh token is valid and new access token is issued");
+        return true;
+      } catch (refreshError) {
+        // refreshToken도 만료된 경우
+        console.log("refresh token is Invalid");
+        return false;
+      }
+    } else {
+      // 다른 종류의 오류
+      console.log("server error");
+      return false;
+    }
+  }
+};

--- a/src/apis/getVerifyToken.tsx
+++ b/src/apis/getVerifyToken.tsx
@@ -1,10 +1,11 @@
 import axios, { AxiosError } from "axios";
 
-export const verifyToken = async () => {
+export const verifyTokenAPI = async () => {
   try {
-    await axios.get("/api/verifyToken");
+    const res = await axios.get("/api/verifyToken");
+    const { login_id, user_name, user_role } = res.data.data;
     console.log("Access token is valid");
-    return true;
+    return { isLogin: true, login_id, user_name, user_role };
   } catch (error) {
     // accessToken이 만료된 경우
     const axiosError = error as AxiosError;
@@ -12,18 +13,19 @@ export const verifyToken = async () => {
 
     if (axiosError.response && axiosError.response.status === 401) {
       try {
-        await axios.get("/api/refreshToken");
+        const res = await axios.get("/api/refreshToken");
+        const { login_id, user_name, user_role } = res.data.data;
         console.log("refresh token is valid and new access token is issued");
-        return true;
+        return { isLogin: true, login_id, user_name, user_role };
       } catch (refreshError) {
         // refreshToken도 만료된 경우
         console.log("refresh token is Invalid");
-        return false;
+        return { isLogin: false, login_id: "", user_name: "", user_role: "" };
       }
     } else {
       // 다른 종류의 오류
       console.log("server error");
-      return false;
+      return { isLogin: false, login_id: "", user_name: "", user_role: "" };
     }
   }
 };

--- a/src/apis/patchUserLogin.tsx
+++ b/src/apis/patchUserLogin.tsx
@@ -1,0 +1,32 @@
+import axios, { AxiosError } from "axios";
+
+interface ErrorResponse {
+  ok: boolean;
+  message: string;
+}
+
+export const patchUserLogin = async (login_id: string, login_pw: string, user_role: "user" | "admin") => {
+  let userLoginInfo = null;
+  let message = "";
+  let isSuccess = true;
+
+  try {
+    const { data } = await axios.patch(`/api/login`, {
+      login_id,
+      login_pw,
+      user_role,
+    });
+    userLoginInfo = data.data;
+    return { isSuccess, userLoginInfo, message };
+  } catch (error) {
+    const axiosError = error as AxiosError<ErrorResponse>;
+
+    isSuccess = false;
+    if (axiosError.response?.status === 401) {
+      message = axiosError.response.data.message;
+    } else {
+      message = "로그인 처리 중 오류가 발생했습니다";
+    }
+    return { isSuccess, userLoginInfo, message };
+  }
+};

--- a/src/apis/patchUserLogout.tsx
+++ b/src/apis/patchUserLogout.tsx
@@ -1,0 +1,11 @@
+import axios from "axios";
+
+interface PropsTpye {
+  ok: boolean;
+  message: string;
+}
+
+export const patchUserLogout = async (): Promise<PropsTpye> => {
+  const { data } = await axios.patch(`/api/logout`);
+  return data;
+};

--- a/src/components/common/SignForm/SignForm.tsx
+++ b/src/components/common/SignForm/SignForm.tsx
@@ -5,8 +5,8 @@ import classNames from "classnames/bind";
 
 interface PropsType {
   children: React.ReactNode;
-  userType: "User" | "Admin";
-  setUserType: (userType: "User" | "Admin") => void;
+  userType: "user" | "admin";
+  setUserType: (userType: "user" | "admin") => void;
 }
 
 const cx = classNames.bind(styles);
@@ -16,10 +16,10 @@ const SignForm: React.FC<PropsType> = ({ children, userType, setUserType }) => {
   return (
     <section className={styles["sign-section"]}>
       <div className={styles["sign-section-buttons"]}>
-        <button type="button" className={cx("sign-section-button", userType === "User" && "active")} onClick={() => setUserType("User")}>
+        <button type="button" className={cx("sign-section-button", userType === "user" && "active")} onClick={() => setUserType("user")}>
           {location.pathname === "/signup" ? "일반 회원가입" : "일반회원 로그인"}
         </button>
-        <button type="button" className={cx("sign-section-button", userType === "Admin" && "active")} onClick={() => setUserType("Admin")}>
+        <button type="button" className={cx("sign-section-button", userType === "admin" && "active")} onClick={() => setUserType("admin")}>
           {location.pathname === "/signup" ? "관리자 회원가입" : "관리자 로그인"}
         </button>
       </div>

--- a/src/components/layouts/Header/Header.tsx
+++ b/src/components/layouts/Header/Header.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { NavigationBar } from "@/components/mypage";
+import { useLoginStore } from "@/stores/useLoginStore";
+import { patchUserLogout } from "@/apis/patchUserLogout";
 import MenuIcon from "@/assets/menu.svg?react";
 import NavbarCloseIcon from "@/assets/navbar-close.svg?react";
 import classNames from "classnames/bind";
@@ -9,9 +11,10 @@ import styles from "./Header.module.css";
 const cx = classNames.bind(styles);
 
 const Header = () => {
-  const [isLogined, setIsLogined] = useState(true);
+  const { userState, setUserState } = useLoginStore();
   const [isMyPageNavbarShow, setIsMyPageNavbarShow] = useState(false);
   const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
 
   const isInMyPage = useMemo(() => location.pathname === "/mypage", [location.pathname]);
 
@@ -29,6 +32,14 @@ const Header = () => {
     setIsMyPageNavbarShow(false);
   };
 
+  const handleLogout = async () => {
+    const res = patchUserLogout();
+    if ((await res).ok) {
+      setUserState({ login_id: "", user_name: "", user_role: "" });
+      navigate("/");
+    }
+  };
+
   return (
     <header className={styles.header}>
       <div className={styles["header-wrapper"]}>
@@ -37,15 +48,13 @@ const Header = () => {
         </h1>
 
         <div className={styles["button-group"]}>
-          {!isLogined && (
+          {userState.login_id === "" ? (
             <Link to="/login" className={styles["button-login"]}>
               로그인
             </Link>
-          )}
-
-          {isLogined && (
+          ) : (
             <>
-              <button type="button" className={cx("button-logout", isInMyPage && "my-page")}>
+              <button type="button" className={cx("button-logout", isInMyPage && "my-page")} onClick={handleLogout}>
                 로그아웃
               </button>
               {!isInMyPage && (

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { verifyTokenAPI } from "@/apis/getVerifyToken";
+import { useLoginStore } from "@/stores/useLoginStore";
+
+interface PropsType {
+  isLogin: boolean;
+  login_id: string;
+  user_name: string;
+  user_role: string;
+}
+
+const useAuth = (
+  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>,
+  setData: React.Dispatch<React.SetStateAction<PropsType | null>>, // 수정된 타입
+  setIsError: React.Dispatch<React.SetStateAction<boolean>>,
+) => {
+  const { setUserState } = useLoginStore();
+
+  useEffect(() => {
+    const verifyToken = async () => {
+      try {
+        const res = await verifyTokenAPI();
+        setIsLoading(false);
+        setData(res);
+        setUserState(res); // setUserState를 호출하여 전역 상태 업데이트
+      } catch (error) {
+        console.error(error);
+        setIsError(true);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    verifyToken();
+  }, [setIsLoading, setData, setIsError, setUserState]);
+};
+
+export default useAuth;

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -1,16 +1,25 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { SignForm, Button, InputField } from "@/components/common";
+import { patchUserLogin } from "@/apis/patchUserLogin";
 import styles from "./LoginPage.module.css";
 
 const LoginPage = () => {
   const [id, setId] = useState("");
   const [password, setPassword] = useState("");
-  const [userType, setUserType] = useState<"User" | "Admin">("User");
+  const [userType, setUserType] = useState<"user" | "admin">("user");
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log(id, password, userType);
+    const res = await patchUserLogin(id, password, userType);
+
+    // TODO: alert 부분은 toast로 변경
+    if (res.isSuccess) {
+      alert("로그인 성공");
+      window.history.back();
+    } else {
+      alert(res.message);
+    }
   };
 
   return (

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -1,13 +1,17 @@
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { SignForm, Button, InputField } from "@/components/common";
 import { patchUserLogin } from "@/apis/patchUserLogin";
+import { useLoginStore } from "@/stores/useLoginStore";
 import styles from "./LoginPage.module.css";
 
 const LoginPage = () => {
   const [id, setId] = useState("");
   const [password, setPassword] = useState("");
   const [userType, setUserType] = useState<"user" | "admin">("user");
+  const { setUserState } = useLoginStore();
+  const navigate = useNavigate();
+  const { state } = useLocation();
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -15,8 +19,14 @@ const LoginPage = () => {
 
     // TODO: alert 부분은 toast로 변경
     if (res.isSuccess) {
-      alert("로그인 성공");
-      window.history.back();
+      // alert("로그인 성공");
+      setUserState(res.userLoginInfo);
+      if (state?.from) {
+        navigate(`${state.from.pathname}`, { replace: true });
+      } else {
+        // TODO: 로그인 버튼을 눌렀을 때, 로그인 이전 페이지로 이동하게 해야 함
+        navigate("/", { replace: true });
+      }
     } else {
       alert(res.message);
     }

--- a/src/stores/useLoginStore.ts
+++ b/src/stores/useLoginStore.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface UserState {
+  login_id: string;
+  user_name: string;
+  user_role: string;
+}
+
+interface useLoginStoreState {
+  userState: UserState;
+  setUserState: (newState: UserState) => void;
+}
+
+export const useLoginStore = create(
+  persist<useLoginStoreState>(
+    (set) => ({
+      userState: {
+        login_id: "",
+        user_name: "",
+        user_role: "",
+      },
+      setUserState: (newState) => set({ userState: newState }),
+    }),
+    {
+      name: "user-storage",
+    },
+  ),
+);


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [x] 기능 추가 : 로그인 및 토큰 검증 기능 추가 / PrivateRoute 설정
- [ ] 마크업 & 스타일 :
- [x] 리팩토링 : 헤더 컴포넌트, 
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

![녹음 2023-12-15 023710 (2)](https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/d61e9bd7-d389-4964-b9ab-b41d8c61dd85)

![녹음 2023-12-15 023812 (1)](https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/d1ddebb5-9169-45ad-a3e6-077297a6fca6)

<br>

## 🌟 전달 사항

- PrivateRoute에서 토큰 검증을 할 때, useQuery를 사용 했으나 계속 데이터 값을 받아오기도 전에 return 시켜서 useEffect 사용 
- App.tsx에서 로그인이 필요한 페이지의 경우 isPrivateRoute에 추가하면 됩니다.
- 토큰 값은 쿠키에 저장 되어 있고 쿠키는 클라이언트에서 조작이 불가합니다. 조회도 안 됨
- 서버에서 토큰 값을 읽고 클라이언트로 보낼 때, 토큰을 제외한 유저 정보만 보냅니다.
- 유저 정보는 Zustand로 localStore에 저장하고 전역으로 관리합니다.
- 마이페이지 들어갔을 때, 강제로 로그인 페이지로 넘어가고 로그인 시 다시 마이페이지로 넘어 가게는 했는데 디테일 페이지나 다른 페이지에서 로그인 페이지로 넘어가고 로그인 시 다시 디테일 페이지로 넘어 가는 것이 아닌 메인 페이지로 일단 넘어갑니다.
- alert를 사용했는데 나중에 toast로 바꿀 예정입니다. 

- 버그 있는지 봐주십셔

<br>

## ⚠️ Issue Number

- #3 #4 

<br><br>
