### PR TITLE
feat/page-login : 라우터마다 로그인 검증 로직 추가 및 기존 PrivateRoute 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,14 @@
-import { Outlet, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import { Header } from "./components/layouts";
 import PrivateRoute from "./PrivateRoute";
 
 function App() {
   const location = useLocation();
 
-  const isPrivateRoute = location.pathname.startsWith("/mypage");
   return (
     <>
       {location.pathname !== "/signup" && location.pathname !== "/login" && <Header />}
-      {isPrivateRoute ? <PrivateRoute /> : <Outlet />}
+      <PrivateRoute />
     </>
   );
 }

--- a/src/PrivateRoute.tsx
+++ b/src/PrivateRoute.tsx
@@ -1,26 +1,23 @@
-import { useState } from "react";
-import { Navigate, useLocation, Outlet } from "react-router-dom";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 import useAuth from "@/hooks/useAuth";
-
-interface PropsType {
-  isLogin: boolean;
-  login_id: string;
-  user_name: string;
-  user_role: string;
-}
+import { useState } from "react";
 
 const PrivateRoute = () => {
+  const { isLoading, isError, user } = useAuth();
   const location = useLocation();
-  const [isLoading, setIsLoading] = useState(true);
-  const [isError, setIsError] = useState(false);
-  const [data, setData] = useState<null | PropsType>(null);
-
-  useAuth(setIsLoading, setData, setIsError);
 
   if (isLoading) return <div>로딩중...</div>;
   if (isError) return <div>error</div>;
 
-  return data?.isLogin ? <Outlet /> : <Navigate to="/login" state={{ from: location }} replace />;
+  const isMyPage = location.pathname.startsWith("/mypage");
+
+  // console.log(user);
+
+  if (isMyPage && !user.isLogin) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return <Outlet />;
 };
 
 export default PrivateRoute;

--- a/src/apis/patchUserLogin.tsx
+++ b/src/apis/patchUserLogin.tsx
@@ -17,6 +17,7 @@ export const patchUserLogin = async (login_id: string, login_pw: string, user_ro
       user_role,
     });
     userLoginInfo = data.data;
+    userLoginInfo["isLogin"] = true;
     return { isSuccess, userLoginInfo, message };
   } catch (error) {
     const axiosError = error as AxiosError<ErrorResponse>;

--- a/src/components/layouts/Header/Header.tsx
+++ b/src/components/layouts/Header/Header.tsx
@@ -35,7 +35,7 @@ const Header = () => {
   const handleLogout = async () => {
     const res = patchUserLogout();
     if ((await res).ok) {
-      setUserState({ login_id: "", user_name: "", user_role: "" });
+      setUserState({ isLogin: false, login_id: "", user_name: "", user_role: "" });
       navigate("/");
     }
   };

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,37 +1,32 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { verifyTokenAPI } from "@/apis/getVerifyToken";
 import { useLoginStore } from "@/stores/useLoginStore";
 
-interface PropsType {
-  isLogin: boolean;
-  login_id: string;
-  user_name: string;
-  user_role: string;
-}
+const useAuth = () => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+  const { userState, setUserState } = useLoginStore();
+  const { pathname } = useLocation();
 
-const useAuth = (
-  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>,
-  setData: React.Dispatch<React.SetStateAction<PropsType | null>>, // 수정된 타입
-  setIsError: React.Dispatch<React.SetStateAction<boolean>>,
-) => {
-  const { setUserState } = useLoginStore();
+  const verifyToken = async () => {
+    try {
+      const res = await verifyTokenAPI();
+      setUserState(res);
+    } catch (error) {
+      console.error(error);
+      setIsError(true);
+      setUserState({ isLogin: false, login_id: "", user_name: "", user_role: "" });
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   useEffect(() => {
-    const verifyToken = async () => {
-      try {
-        const res = await verifyTokenAPI();
-        setIsLoading(false);
-        setData(res);
-        setUserState(res); // setUserState를 호출하여 전역 상태 업데이트
-      } catch (error) {
-        console.error(error);
-        setIsError(true);
-      } finally {
-        setIsLoading(false);
-      }
-    };
     verifyToken();
-  }, [setIsLoading, setData, setIsError, setUserState]);
+  }, [pathname]); // Removed pathname dependency to avoid unnecessary re-verifications
+
+  return { isLoading, isError, user: userState };
 };
 
 export default useAuth;

--- a/src/stores/useLoginStore.ts
+++ b/src/stores/useLoginStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 interface UserState {
+  isLogin: boolean;
   login_id: string;
   user_name: string;
   user_role: string;
@@ -16,6 +17,7 @@ export const useLoginStore = create(
   persist<useLoginStoreState>(
     (set) => ({
       userState: {
+        isLogin: false,
         login_id: "",
         user_name: "",
         user_role: "",


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [ ] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [x] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

- 페이지 이동 시마다 유저 검증
- PrivateRoute 수정

<br>

## 🌟 전달 사항

- 페이지 이동할 때마다 유저 검증을 합니다.
- 게시글, 댓글, 좋아요 누를 때 accessToken 검증을 하는데, 마이페이지에서만 검증하던 로직을 페이지 이동할 때마다 검증하는 것으로 변경했습니다.
- 다만, 한 페이지에 계속 머물다가 위의 기능을 하려고 하면 로그인하라는 알림이 뜰 겁니다.
- 그것을 방지하기 위해 기존 1시간이던 accessToken을 5시간으로 늘렸습니다.!

<br>

## ⚠️ Issue Number

- #3 #4 

<br><br>
