### PR TITLE
refactor/toastify: toastify 스타일 Toast Emitter -> Toast Container

### DIFF
--- a/src/components/detail/InfoSection/InfoSection.tsx
+++ b/src/components/detail/InfoSection/InfoSection.tsx
@@ -9,16 +9,7 @@ type onCopyFn = (text: string) => void;
 const copyClipBoard: onCopyFn = async (text: string) => {
   try {
     await navigator.clipboard.writeText(text);
-    toast.info("클립보드에 복사되었습니다.", {
-      position: "top-center",
-      autoClose: 1000,
-      hideProgressBar: false,
-      closeOnClick: true,
-      pauseOnHover: true,
-      draggable: true,
-      progress: undefined,
-      theme: "light",
-    });
+    toast.info("클립보드에 복사되었습니다.");
   } catch (error) {
     console.error(error);
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,7 +15,15 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
-      <ToastContainer />
+      <ToastContainer
+        position="top-center"
+        autoClose={1000}
+        hideProgressBar={false}
+        closeOnClick={true}
+        pauseOnHover={true}
+        draggable={true}
+        theme="light"
+      />
     </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/src/toast.css
+++ b/src/toast.css
@@ -1,6 +1,6 @@
 .Toastify__progress-bar--info {
-  background-color: var(--main-color);
+  background-color: var(--gray300-color);
 }
-.Toastify__toast-icon > svg {
-  fill: var(--main-color);
+.Toastify__toast--info .Toastify__toast-icon > svg {
+  fill: var(--gray300-color);
 }


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [ ] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [x] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [x] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

- toast를 사용하는 곳(toastify emitter)에서 스타일링을 하는 방식에서 
  최상단에 있는 toastify container에 스타일링을 고정으로 주는 것으로 리팩했습니다

<br>

## 🌟 전달 사항

- toastify 사용법
   - toast.info('msg') : 회색 (커스텀 / toast.css 참고)
   - toast.error('msg') : 빨간색 (기본값)
   - toast.warn('msg') : 노란색 (기본값)

<br>

## ⚠️ Issue Number

-

<br><br>
