### PR TITLE
feat/page-detail: 상세 페이지 InfoSection 소개, 지도관련 작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "react-datepicker": "^4.24.0",
         "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.2.0",
-        "react-kakao-maps-sdk": "^1.1.24",
         "react-loading-skeleton": "^3.3.1",
         "react-router-dom": "^6.20.1",
         "react-slick": "^0.29.0",
@@ -3741,11 +3740,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/kakao.maps.d.ts": {
-      "version": "0.1.39",
-      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.39.tgz",
-      "integrity": "sha512-KXENJ8hHYtjb5G+0vf8TXx/PwWW4j5ndDiQTSMvGtF7EFWu2P3N/+Zivcj9/UKn3j29Iz/sIUaA7WL8Ug3IDGQ=="
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4433,19 +4427,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/react-kakao-maps-sdk": {
-      "version": "1.1.24",
-      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.1.24.tgz",
-      "integrity": "sha512-leLbFwBj6zbTdDg6A9U7EwYT2oq0+2F+NHZSVTyCmmvyc4yt2zpRvUmcAt8I6h2SDUdgHbpvKAV1sZoRIxD4JQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.15",
-        "kakao.maps.d.ts": "^0.1.39"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18",
-        "react-dom": "^16.8 || ^17 || ^18"
-      }
     },
     "node_modules/react-loading-skeleton": {
       "version": "3.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "eslint": "^8.53.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.4",
+        "kakao.maps.d.ts": "^0.1.39",
         "typescript": "^5.2.2",
         "vite": "^5.0.0"
       }
@@ -3739,6 +3740,12 @@
       "engines": {
         "node": ">=0.6.0"
       }
+    },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.39",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.39.tgz",
+      "integrity": "sha512-KXENJ8hHYtjb5G+0vf8TXx/PwWW4j5ndDiQTSMvGtF7EFWu2P3N/+Zivcj9/UKn3j29Iz/sIUaA7WL8Ug3IDGQ==",
+      "dev": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint": "^8.53.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.4",
+    "kakao.maps.d.ts": "^0.1.39",
     "typescript": "^5.2.2",
     "vite": "^5.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "react-datepicker": "^4.24.0",
     "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.2.0",
-    "react-kakao-maps-sdk": "^1.1.24",
     "react-loading-skeleton": "^3.3.1",
     "react-router-dom": "^6.20.1",
     "react-slick": "^0.29.0",

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -29,4 +29,5 @@ export {
   patchReview,
   postLike,
   deleteLike,
+  getUserLikeList,
 };

--- a/src/components/detail/InfoSection/InfoSection.module.css
+++ b/src/components/detail/InfoSection/InfoSection.module.css
@@ -71,3 +71,36 @@
   border-radius: 5px;
   padding: 0.3rem 0.4rem;
 }
+
+/* 소개 */
+.info-description__content {
+  margin: 1rem 0;
+  padding: 1rem;
+  background-color: var(--gray100-color);
+}
+
+.info-description h4 {
+  font-size: 1.2rem;
+}
+
+.info-description h5 {
+  font-size: 1.1rem;
+}
+
+.info-description h6 {
+  font-size: 1rem;
+}
+
+.info-description p {
+  font-size: 0.8rem;
+}
+
+.info-description ul {
+  list-style-type: disc;
+  list-style-position: inside;
+}
+
+.info-description ol {
+  list-style-type: decimal;
+  list-style-position: inside;
+}

--- a/src/components/detail/InfoSection/InfoSection.module.css
+++ b/src/components/detail/InfoSection/InfoSection.module.css
@@ -78,6 +78,11 @@
   padding: 1rem;
   background-color: var(--gray100-color);
 }
+.info-description__content * {
+  width: 100%;
+  text-wrap: wrap;
+  line-height: 1.2rem;
+}
 
 .info-description h4 {
   font-size: 1.2rem;
@@ -94,13 +99,17 @@
 .info-description p {
   font-size: 0.8rem;
 }
+.info-description ul,
+.info-description ol {
+  font-size: 0.8rem;
+  list-style-position: inside;
+  margin: 0.5rem 0;
+}
 
 .info-description ul {
   list-style-type: disc;
-  list-style-position: inside;
 }
 
 .info-description ol {
   list-style-type: decimal;
-  list-style-position: inside;
 }

--- a/src/components/detail/InfoSection/InfoSection.tsx
+++ b/src/components/detail/InfoSection/InfoSection.tsx
@@ -24,16 +24,45 @@ const copyClipBoard: onCopyFn = async (text: string) => {
   }
 };
 
+// const decodeBase64UrlSafe = (input: string) => {
+//   // URL-safe base64 decoding
+//   const base64 = input.replace(/-/g, "+").replace(/_/g, "/");
+//   try {
+//     return window.atob(base64);
+//   } catch (error) {
+//     console.error("Error decoding base64:", error);
+//     return "";
+//   }
+// };
+
+const decodeUnicode = (str) => {
+  // try {
+  //   // const decodedBase64 = decodeBase64UrlSafe(str);
+  //   return decodeURIComponent(
+  //     str
+  //       .split("")
+  //       .map((c) => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
+  //       .join(""),
+  //   );
+  // } catch (error) {
+  //   console.error("Error decoding Unicode:", error);
+  //   return "";
+  // }
+  return str;
+};
+
 const InfoSection = () => {
   const { showInfo } = useShowInfoStore();
   if (!showInfo) return <h2>loading...</h2>;
 
   const { univ, department, title, location, start_date, end_date } = showInfo;
 
-  const tags = showInfo.tags && Object.values(JSON.parse(showInfo.tags));
+  const tags = (showInfo.tags && showInfo.tags.length && Object.values(JSON.parse(showInfo.tags))) || [];
   const position = showInfo.position && JSON.parse(showInfo.position);
+
   const contentBufferData = showInfo.content && new Uint8Array(showInfo.content.data);
   const contentDecodedString = contentBufferData && new TextDecoder("utf-8").decode(contentBufferData);
+  const content = contentDecodedString ? decodeUnicode(contentDecodedString) : null;
 
   return (
     <>
@@ -44,20 +73,23 @@ const InfoSection = () => {
           <h4 className={styles["info-title__title"]}>{title}</h4>
           <p className={styles["info-title__date"]}>{start_date + " ~ " + end_date}</p>
           <p className={styles["info-title__location"]}>{location}</p>
-          <ul className={styles["info-title__tags"]}>
-            {tags.map((tag) => (
-              <li key={tag} className={styles.tag}>
-                {tag}
-              </li>
-            ))}
-          </ul>
+          {!tags.length && (
+            <ul className={styles["info-title__tags"]}>
+              {tags.map((tag) => (
+                <li key={tag} className={styles.tag}>
+                  {tag}
+                </li>
+              ))}
+            </ul>
+          )}
         </section>
 
-        <section className={styles["info-description"]}>
-          <h3>소개</h3>
-          {/* 커스텀 글 내용 */}
-          <div>{contentDecodedString}</div>
-        </section>
+        {content && (
+          <section className={styles["info-description"]}>
+            <h3>소개</h3>
+            <pre className={styles["info-description__content"]} dangerouslySetInnerHTML={{ __html: content }}></pre>
+          </section>
+        )}
 
         <section className={styles["info-location"]}>
           <h3 className="a11y-hidden">지도</h3>

--- a/src/components/detail/InfoSection/InfoSection.tsx
+++ b/src/components/detail/InfoSection/InfoSection.tsx
@@ -15,45 +15,26 @@ const copyClipBoard: onCopyFn = async (text: string) => {
   }
 };
 
-// const decodeBase64UrlSafe = (input: string) => {
-//   // URL-safe base64 decoding
-//   const base64 = input.replace(/-/g, "+").replace(/_/g, "/");
-//   try {
-//     return window.atob(base64);
-//   } catch (error) {
-//     console.error("Error decoding base64:", error);
-//     return "";
-//   }
-// };
-
-const decodeUnicode = (str) => {
-  // try {
-  //   // const decodedBase64 = decodeBase64UrlSafe(str);
-  //   return decodeURIComponent(
-  //     str
-  //       .split("")
-  //       .map((c) => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
-  //       .join(""),
-  //   );
-  // } catch (error) {
-  //   console.error("Error decoding Unicode:", error);
-  //   return "";
-  // }
-  return str;
-};
+// 디코딩
+function base64ToBytes(base64: string): Uint8Array {
+  try {
+    const binString = window.atob(base64);
+    return Uint8Array.from(binString, (c) => c.codePointAt(0) ?? 0);
+  } catch (error) {
+    console.error("Error decoding base64:", error);
+    return new Uint8Array();
+  }
+}
 
 const InfoSection = () => {
   const { showInfo } = useShowInfoStore();
   if (!showInfo) return <h2>loading...</h2>;
 
-  const { univ, department, title, location, start_date, end_date } = showInfo;
+  const { univ, department, title, location, location_detail, start_date, end_date } = showInfo;
 
   const tags = (showInfo.tags && showInfo.tags.length && Object.values(JSON.parse(showInfo.tags))) || [];
   const position = showInfo.position && JSON.parse(showInfo.position);
-
-  const contentBufferData = showInfo.content && new Uint8Array(showInfo.content.data);
-  const contentDecodedString = contentBufferData && new TextDecoder("utf-8").decode(contentBufferData);
-  const content = contentDecodedString ? decodeUnicode(contentDecodedString) : null;
+  const decodedContent = showInfo.content ? new TextDecoder().decode(base64ToBytes(showInfo.content)) : null;
 
   return (
     <>
@@ -63,7 +44,7 @@ const InfoSection = () => {
           <p className={styles["info-title__organizer"]}>{univ + " " + department}</p>
           <h4 className={styles["info-title__title"]}>{title}</h4>
           <p className={styles["info-title__date"]}>{start_date + " ~ " + end_date}</p>
-          <p className={styles["info-title__location"]}>{location}</p>
+          <p className={styles["info-title__location"]}>{location + " " + location_detail}</p>
           {!!tags.length && (
             <ul className={styles["info-title__tags"]}>
               {tags.map((tag) => (
@@ -75,10 +56,10 @@ const InfoSection = () => {
           )}
         </section>
 
-        {content && (
+        {decodedContent && (
           <section className={styles["info-description"]}>
             <h3>소개</h3>
-            <pre className={styles["info-description__content"]} dangerouslySetInnerHTML={{ __html: content }}></pre>
+            <pre className={styles["info-description__content"]} dangerouslySetInnerHTML={{ __html: decodedContent }}></pre>
           </section>
         )}
 

--- a/src/components/detail/InfoSection/InfoSection.tsx
+++ b/src/components/detail/InfoSection/InfoSection.tsx
@@ -32,7 +32,7 @@ const InfoSection = () => {
 
   const { univ, department, title, location, location_detail, start_date, end_date } = showInfo;
 
-  const tags = (showInfo.tags && showInfo.tags.length && Object.values(JSON.parse(showInfo.tags))) || [];
+  const tags: string[] = showInfo.tags ? Object.values(JSON.parse(showInfo.tags)) : [];
   const position = showInfo.position && JSON.parse(showInfo.position);
   const decodedContent = showInfo.content ? new TextDecoder().decode(base64ToBytes(showInfo.content)) : null;
 

--- a/src/components/detail/InfoSection/LocationMap.tsx
+++ b/src/components/detail/InfoSection/LocationMap.tsx
@@ -1,51 +1,46 @@
-import { Map, MapMarker, useKakaoLoader } from "react-kakao-maps-sdk";
+import { useEffect, useState } from "react";
 import mapPinIcon from "@/assets/icon-map-pin.svg";
 
-const apiKey = import.meta.env.VITE_APP_KAKAOMAP_API_KEY as string;
+const { kakao } = window;
 
 interface PropsType {
   lat: number;
   lng: number;
 }
 
-export default function LocationMap({ lat, lng }: PropsType) {
-  useKakaoLoader({ appkey: apiKey });
+export default function LocationMap({ lat = 127.055596615858, lng = 37.5069494959122 }: PropsType) {
+  // const [map, setMap] = useState(null);
+
+  useEffect(() => {
+    const container = document.getElementById("map");
+    const options = {
+      center: new kakao.maps.LatLng(lat, lng),
+      level: 4, // 지도의 확대 레벨
+    };
+    const map = new kakao.maps.Map(container, options);
+    // setMap(kakaoMap);
+
+    const imageSrc = mapPinIcon; // 마커이미지의 주소입니다
+    const imageSize = new kakao.maps.Size(29, 42); // 마커이미지의 크기입니다
+    const imageOption = { offset: new kakao.maps.Point(14.5, 42) }; // 마커이미지의 옵션입니다. 마커의 좌표와 일치시킬 이미지 안에서의 좌표를 설정합니다.
+
+    // 마커의 이미지정보를 가지고 있는 마커이미지를 생성합니다
+    var markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize, imageOption);
+
+    const marker = new kakao.maps.Marker({
+      position: new kakao.maps.LatLng(lat, lng),
+      image: markerImage,
+    });
+    marker.setMap(map);
+  }, []);
 
   return (
-    <Map // 지도를 표시할 Container
+    <div
       id="map"
-      center={{
-        // 지도의 중심좌표
-        lat,
-        lng,
-      }}
       style={{
-        // 지도의 크기
         width: "100%",
         height: "400px",
       }}
-      level={4} // 지도의 확대 레벨
-    >
-      <MapMarker // 마커를 생성합니다
-        position={{
-          // 마커가 표시될 위치입니다
-          lat,
-          lng,
-        }}
-        image={{
-          src: mapPinIcon, // 마커이미지의 주소입니다
-          size: {
-            width: 29,
-            height: 42,
-          }, // 마커이미지의 크기입니다
-          options: {
-            offset: {
-              x: 14.5,
-              y: 42,
-            }, // 마커이미지의 옵션입니다. 마커의 좌표와 일치시킬 이미지 안에서의 좌표를 설정합니다.
-          },
-        }}
-      />
-    </Map>
+    ></div>
   );
 }

--- a/src/components/detail/InfoSection/LocationMap.tsx
+++ b/src/components/detail/InfoSection/LocationMap.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef } from "react";
 import mapPinIcon from "@/assets/icon-map-pin.svg";
 
 const { kakao } = window;
@@ -8,17 +8,15 @@ interface PropsType {
   lng: number;
 }
 
-export default function LocationMap({ lat = 127.055596615858, lng = 37.5069494959122 }: PropsType) {
-  // const [map, setMap] = useState(null);
-
+export default function LocationMap({ lat, lng }: PropsType) {
+  const mapRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    const container = document.getElementById("map");
+    const container = mapRef.current;
     const options = {
       center: new kakao.maps.LatLng(lat, lng),
       level: 4, // 지도의 확대 레벨
     };
-    const map = new kakao.maps.Map(container, options);
-    // setMap(kakaoMap);
+    var map = new kakao.maps.Map(container as HTMLDivElement, options);
 
     const imageSrc = mapPinIcon; // 마커이미지의 주소입니다
     const imageSize = new kakao.maps.Size(29, 42); // 마커이미지의 크기입니다
@@ -32,11 +30,12 @@ export default function LocationMap({ lat = 127.055596615858, lng = 37.506949495
       image: markerImage,
     });
     marker.setMap(map);
-  }, []);
+  }, [lat, lng]);
 
   return (
     <div
-      id="map"
+      ref={mapRef}
+      // id="map"
       style={{
         width: "100%",
         height: "400px",

--- a/src/components/main/Postcode/Postcode.tsx
+++ b/src/components/main/Postcode/Postcode.tsx
@@ -1,6 +1,7 @@
-import { Button } from "@/components/common";
 import React, { SetStateAction } from "react";
-import { useDaumPostcodePopup } from "react-daum-postcode";
+import { Button } from "@/components/common";
+import { useDaumPostcodePopup, Address } from "react-daum-postcode";
+import { AddressSearchResult } from "@/types/addressSearchType";
 
 const kakao = window.kakao;
 
@@ -8,9 +9,9 @@ const getAddressCoords = (address: string) => {
   const geoCoder = new kakao.maps.services.Geocoder();
 
   return new Promise((resolve, reject) => {
-    geoCoder.addressSearch(address, (result: any, status: any) => {
+    geoCoder.addressSearch(address, (result: AddressSearchResult[], status: any) => {
       if (status === kakao.maps.services.Status.OK) {
-        const coords = new kakao.maps.LatLng(result[0].x, result[0].y);
+        const coords = new kakao.maps.LatLng(+result[0].x, +result[0].y);
         resolve(coords);
       } else {
         reject(status);
@@ -19,21 +20,18 @@ const getAddressCoords = (address: string) => {
   });
 };
 
-const getPosition = async (data) => {
-  let mainAddress = "";
-  let x = 0;
-  let y = 0;
+const getPosition = async (data: Address) => {
+  try {
+    const coords = await getAddressCoords(data.roadAddress || data.jibunAddress);
+    const x = coords.getLng();
+    const y = coords.getLat();
 
-  mainAddress = data.roadAddress || data.jibunAddress;
-
-  const coords = await getAddressCoords(mainAddress);
-  x = coords.getLng();
-  y = coords.getLat();
-
-  return { lat: x, lng: y };
+    return { lat: x, lng: y };
+  } catch (e) {
+    console.error(e);
+  }
 };
-
-const getLocation = (data) => {
+const getLocation = (data: Address) => {
   let fullAddress = data.address;
   let extraAddress = ""; //추가될 주소
   // let localAddress = data.sido + ' ' + data.sigungu; //지역주소(시, 도 + 시, 군, 구)
@@ -64,11 +62,17 @@ interface PropsType {
 const Postcode: React.FC<PropsType> = ({ setPosition, setLocation }) => {
   const open = useDaumPostcodePopup();
 
-  const handleComplete = async (data) => {
-    // position
-    setPosition(await getPosition(data));
-    // location
-    setLocation(await getLocation(data));
+  const handleComplete = async (data: Address) => {
+    try {
+      const position = await getPosition(data);
+
+      if (position) {
+        setLocation(await getLocation(data));
+        setPosition(position);
+      }
+    } catch (e) {
+      console.error(e);
+    }
   };
 
   const handleClick = () => {

--- a/src/components/main/Postcode/Postcode.tsx
+++ b/src/components/main/Postcode/Postcode.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/common";
-import React from "react";
+import React, { SetStateAction } from "react";
 import { useDaumPostcodePopup } from "react-daum-postcode";
 
 const kakao = window.kakao;
@@ -30,8 +30,7 @@ const getPosition = async (data) => {
   x = coords.getLng();
   y = coords.getLat();
 
-  console.log(x, y);
-  return { lng: x, lat: y };
+  return { lat: x, lng: y };
 };
 
 const getLocation = (data) => {
@@ -57,14 +56,19 @@ const getLocation = (data) => {
   return fullAddress;
 };
 
-const Postcode = ({ setPosition, setLocation }) => {
+interface PropsType {
+  setPosition: React.Dispatch<SetStateAction<object>>;
+  setLocation: React.Dispatch<SetStateAction<string>>;
+}
+
+const Postcode: React.FC<PropsType> = ({ setPosition, setLocation }) => {
   const open = useDaumPostcodePopup();
 
-  const handleComplete = (data) => {
+  const handleComplete = async (data) => {
     // position
-    setPosition(getPosition(data));
+    setPosition(await getPosition(data));
     // location
-    setLocation(getLocation(data));
+    setLocation(await getLocation(data));
   };
 
   const handleClick = () => {

--- a/src/components/mypage/PostUpload/PostUpload.tsx
+++ b/src/components/mypage/PostUpload/PostUpload.tsx
@@ -39,14 +39,9 @@ const showingDummy: ShowType = {
   location_detail: null,
   position: '{"lat": 37.5069494959122, "lng": 127.055596615858}',
   tags: '{"1": "abc", "2": "def", "3": "ghi"}',
-  content: {
-    type: "Buffer",
-    data: [
-      236, 130, 172, 235, 158, 145, 236, 157, 152, 32, 235, 172, 152, 236, 149, 189, 32, 236, 151, 176, 234, 183, 185, 32, 235, 130, 180, 236, 154,
-      169, 46, 46, 46,
-    ],
-  },
+  content: "",
   is_reservation: 1,
+  // user_liked: 0,
   created_at: "2023-12-07T23:28:49.000Z",
 };
 
@@ -58,7 +53,6 @@ const showReservationInfoDummy: ShowReservationInfoType = {
   price: 1000,
   location: "서울시 강남구 대학로 예술극장",
   location_detail: null,
-  // TODO: 좌표구하기
   position: '{"lat": 37.5069494959122, "lng": 127.055596615858}',
   head_count: 20,
   notice: {
@@ -76,6 +70,12 @@ const showTimesDummy = {
   head_count: 20,
 };
 
+// 인코딩
+function bytesToBase64(bytes: Uint8Array): string {
+  const binString = String.fromCodePoint(...Array.from(bytes));
+  return btoa(binString);
+}
+
 // TODO: 수정 페이지 고려
 const PostUpload = () => {
   const [initialForm, setInitialForm] = useState({
@@ -90,7 +90,7 @@ const PostUpload = () => {
     end_date: "",
     location: "",
     location_detail: "",
-    position: {},
+    position: (showingDummy.position && JSON.parse(showingDummy.position)) || { lat: 0, lng: 0 },
     tags: [],
     content: "",
     is_reservation: showingDummy.is_reservation ? "예" : "아니오",
@@ -107,12 +107,7 @@ const PostUpload = () => {
   const [imgFiles, setImgFiles] = useState<File[]>([]);
   const [imgPreviewUrls, setImgPreviewUrls] = useState<string[]>([]);
   const [location, setLocation] = useState<string>(form.location || "");
-  const [position, setPosition] = useState(
-    form.position || {
-      lat: 0,
-      lng: 0,
-    },
-  );
+  const [position, setPosition] = useState(form.position);
   const [date, setDate] = useState({
     start_date: showingDummy.start_date || "",
     end_date: showingDummy.end_date || "",
@@ -192,8 +187,9 @@ const PostUpload = () => {
 
     const tags = JSON.stringify(convertArrayToObject(tagsInput));
 
-    const base64EncodedContents = editorData && btoa(encodeURIComponent(editorData));
-    const base64EncodedNotice = (form.method === "예매 대행" && btoa(encodeURIComponent(editorNoticeData))) || null;
+    const base64EncodedContents = (!!editorData && bytesToBase64(new TextEncoder().encode(editorData))) || null;
+    const base64EncodedNotice =
+      (form.method === "예매 대행" && !!editorNoticeData && bytesToBase64(new TextEncoder().encode(editorNoticeData))) || null;
 
     const roundListToDateTime = () => {
       return roundList.map((item) => item.date + " - " + item.time);

--- a/src/types/addressSearchType.ts
+++ b/src/types/addressSearchType.ts
@@ -1,0 +1,49 @@
+export interface AddressSearchResponseType {
+  documents: AddressSearchResult[];
+  meta: Meta;
+}
+
+export interface AddressSearchResult {
+  address: Address;
+  address_name: string;
+  address_type: string;
+  road_address: RoadAddress;
+  x: string;
+  y: string;
+}
+
+export interface Address {
+  address_name: string;
+  b_code: string;
+  h_code: string;
+  main_address_no: string;
+  mountain_yn: string;
+  region_1depth_name: string;
+  region_2depth_name: string;
+  region_3depth_h_name: string;
+  region_3depth_name: string;
+  sub_address_no: string;
+  x: string;
+  y: string;
+}
+
+export interface RoadAddress {
+  address_name: string;
+  building_name: string;
+  main_building_no: string;
+  region_1depth_name: string;
+  region_2depth_name: string;
+  region_3depth_name: string;
+  road_name: string;
+  sub_building_no: string;
+  underground_yn: string;
+  x: string;
+  y: string;
+  zone_no: string;
+}
+
+export interface Meta {
+  is_end: boolean;
+  pageable_count: number;
+  total_count: number;
+}

--- a/src/types/showType.ts
+++ b/src/types/showType.ts
@@ -19,15 +19,10 @@ export interface ShowType {
   univ: string;
   department: string;
   tags: string | null;
-  content: Content;
+  content: string;
   is_reservation: number;
   user_liked: 0 | 1;
   created_at: string;
-}
-
-export interface Content {
-  type: string;
-  data: number[];
 }
 
 export interface ShowFilterRequestType {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,9 +24,9 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": ["kakao.maps.d.ts"]
   },
   "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }],
-  "types": "kakao.maps.d.ts"
+  "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [x] 기능 추가 : 인코딩 및 디코딩
- [x] 마크업 & 스타일 : 게시글 소개 부분 스타일
- [x] 리팩토링 : 지도 api
- [ ] 문서 수정 :
- [x] 버그 수정 : postcode에서 좌표 구하고 x, y좌표 잘못넣은 버그 수정
- [ ] 도와주세요 :
- [x] 개발 환경 세팅 : react-kakao-map-sdk 라이브러리 제거

<br>

## 💡 상세 작업 내용

<img width=500 src=https://github.com/FESP-TEAM-1/beta-frontend/assets/90684277/8bd29e31-a56a-4343-8338-739e52fe9666) />

```
// 디코딩
function base64ToBytes(base64: string): Uint8Array {
  try {
    const binString = window.atob(base64);
    return Uint8Array.from(binString, (c) => c.codePointAt(0) ?? 0);
  } catch (error) {
    console.error("Error decoding base64:", error);
    return new Uint8Array();
  }
}

new TextDecoder().decode(base64ToBytes(showInfo.content))
```

```
// 인코딩
function bytesToBase64(bytes: Uint8Array): string {
  const binString = String.fromCodePoint(...Array.from(bytes));
  return btoa(binString);
}

bytesToBase64(new TextEncoder().encode(editorData)))
```


- 소개 
   - content type이 buffer에서 string으로 변경되어 이에 맞는 encode, decode 함수 생성 및 적용
   - [상세 페이지](https://github.com/FESP-TEAM-1/beta-frontend/compare/feat/page-detail?expand=1#diff-eece5258a0c71e949a7c8ece14c1604fd8b1fe2e365884e5711f49e8d1c40ad0) 62번째 줄에 dangerouslySetInnerHTML사용해서 editor를 통해 작성한 마크업대로 데이터 뿌렸구요
      [해당 스타일](https://github.com/FESP-TEAM-1/beta-frontend/compare/feat/page-detail?expand=1#diff-eece5258a0c71e949a7c8ece14c1604fd8b1fe2e365884e5711f49e8d1c40ad0)도 추가했습니다!
- 지도 
   - 게시글 업로드할 때 주소에 해당하는 좌표를 구하면서 (react-kakao-map-sdk 말고) 원래 kakaomap api (kakao.maps.services.Geocoder)를 사용해야하는데, 굳이 라이브러리랑 둘 다 쓸 필요없을 것 같아서 라이브러리 삭제하고 기본 코드로 리액트에 맞게 리팩토링했습니다

<br>

## 🌟 전달 사항

- (인코딩과 디코딩이 밀접한 관련이 있어 해당 브랜치에서 둘 다(상세 페이지, 게시글 업로드 페이지) 작업했어요)

<br>

## ⚠️ Issue Number

- #1 
- #45 

<br><br>
