### PR TITLE
feat/page-mypage-show-manage: 게시글 관리 페이지 리스트 GET, 후기 GET/DELETE 기능 구현

### DIFF
--- a/src/apis/getMyShowList.ts
+++ b/src/apis/getMyShowList.ts
@@ -1,0 +1,19 @@
+import { ShowType } from "@/types";
+import axios from "axios";
+
+interface ShowListResponse {
+  ok: boolean;
+  data: ShowListItemType[];
+}
+
+interface ShowListItemType extends Omit<ShowType, "user_liked"> {
+  likes_count: number;
+  reviews_count: number;
+}
+
+const getMyShowList = async () => {
+  const { data } = await axios<ShowListResponse>("/api/show/user");
+  return data.data;
+};
+
+export default getMyShowList;

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -13,6 +13,7 @@ import deleteReview from "./deleteReview";
 import patchReview from "./patchReview";
 import postLike from "./postLike";
 import deleteLike from "./deleteLike";
+import getMyShowList from "./getMyShowList";
 
 export {
   getShows,
@@ -29,4 +30,6 @@ export {
   patchReview,
   postLike,
   deleteLike,
+  getUserLikeList,
+  getMyShowList,
 };

--- a/src/components/mypage/PostManage/PostManage.module.css
+++ b/src/components/mypage/PostManage/PostManage.module.css
@@ -126,10 +126,11 @@ svg.cmt-icon {
 }
 
 .review-contents {
-  padding: 1.5rem 1.875rem;
+  padding: 1.5rem 1.875rem 2rem 1.875rem;
   border: 1px solid var(--gray100-color);
   border-radius: 10px;
   position: relative;
+  flex-grow: 1;
 }
 
 .review__nickname {
@@ -142,11 +143,12 @@ svg.cmt-icon {
 .review__content {
   font-size: 0.75rem;
   color: var(--gray400-color);
+  word-break: break-all;
 }
 
 .review__date {
   position: absolute;
-  bottom: 0.375rem;
+  bottom: 0.8rem;
   right: 0.9375rem;
   font-size: 0.625rem;
   font-weight: bold;

--- a/src/components/mypage/PostManage/PostManage.tsx
+++ b/src/components/mypage/PostManage/PostManage.tsx
@@ -5,53 +5,58 @@ import CommentIcon from "@/assets/comment.svg?react";
 import classNames from "classnames/bind";
 import styles from "./PostManage.module.css";
 import LikeIcon from "@/assets/like.svg?react";
+import { useQuery } from "@tanstack/react-query";
+import { getMyShowList } from "@/apis";
 
 const cx = classNames.bind(styles);
 
-const item = {
-  title: "서울대학교 산업디자인학과 23년 졸전 놀러오세요",
-  date: "2023.12.04 ~ 2023.12.08",
-  likeCount: 46,
-  reviewCount: 2,
-  id: 4,
-};
 const PostManage = () => {
   const navigate = useNavigate();
   const { openModal, setOpenModal } = useModalStore();
+
+  const {
+    status,
+    data: showList,
+    error,
+  } = useQuery({
+    queryKey: ["showList"],
+    queryFn: () => getMyShowList(),
+  });
+
+  if (status === "pending") return <h1>loading...</h1>;
+  if (status === "error") return <h1>{error.message}</h1>;
 
   return (
     <>
       <div className={styles["container"]}>
         <ul className={styles["list"]}>
-          {Array(5)
-            .fill(item)
-            .map((item) => (
-              <li className={cx("list-row", "list-item")}>
-                <Link to={"/detail/3"} className={styles["list-row-left"]}>
-                  <h3 className={cx("list-item__title", "ellipsis-multi")}>{item.title}</h3>
-                  <p className={styles["list-item__date"]}>{item.date}</p>
-                </Link>
-                <div className={styles["list-row-right"]}>
-                  <div className={styles["like-cnt"]}>
-                    <LikeIcon />
-                    <span>{item.likeCount}</span>
-                  </div>
-                  <Button
-                    reverseColor={true}
-                    onClick={() => {
-                      setOpenModal({ state: true, type: "" });
-                    }}
-                    style={{ padding: "0.6rem" }}
-                  >
-                    <CommentIcon className={styles["cmt-icon"]} />
-                    <span>{item.reviewCount}</span>
-                  </Button>
-                  <Button reverseColor={true} style={{ padding: "0.6rem" }}>
-                    수정/삭제
-                  </Button>
+          {showList.map((item) => (
+            <li className={cx("list-row", "list-item")}>
+              <Link to={"/detail/3"} className={styles["list-row-left"]}>
+                <h3 className={cx("list-item__title", "ellipsis-multi")}>{item.title}</h3>
+                <p className={styles["list-item__date"]}>{item.start_date + " ~ " + item.end_date}</p>
+              </Link>
+              <div className={styles["list-row-right"]}>
+                <div className={styles["like-cnt"]}>
+                  <LikeIcon />
+                  <span>{item.likes_count}</span>
                 </div>
-              </li>
-            ))}
+                <Button
+                  reverseColor={true}
+                  onClick={() => {
+                    setOpenModal({ state: true, type: "" });
+                  }}
+                  style={{ padding: "0.6rem" }}
+                >
+                  <CommentIcon className={styles["cmt-icon"]} />
+                  <span>{item.reviews_count}</span>
+                </Button>
+                <Button reverseColor={true} style={{ padding: "0.6rem" }} onClick={() => navigate("./update", { state: item.id })}>
+                  수정/삭제
+                </Button>
+              </div>
+            </li>
+          ))}
         </ul>
       </div>
       <Button style={{ fontSize: "0.75rem", width: "fit-content", marginLeft: "auto" }} onClick={() => navigate("./upload")}>

--- a/src/components/mypage/PostManage/PostManage.tsx
+++ b/src/components/mypage/PostManage/PostManage.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Button, Modal, DeleteButton } from "@/components/common";
 import { useModalStore } from "@/stores/useModalStore";
@@ -6,13 +7,16 @@ import classNames from "classnames/bind";
 import styles from "./PostManage.module.css";
 import LikeIcon from "@/assets/like.svg?react";
 import { useQuery } from "@tanstack/react-query";
-import { getMyShowList } from "@/apis";
+import { getMyShowList, getReviews } from "@/apis";
+import { ReviewType } from "@/types";
+import getElapsedTime from "@/utils/getElapsedTime";
 
 const cx = classNames.bind(styles);
 
 const PostManage = () => {
   const navigate = useNavigate();
   const { openModal, setOpenModal } = useModalStore();
+  const [reviewData, setReviewData] = useState<ReviewType[]>([]);
 
   const {
     status,
@@ -26,30 +30,41 @@ const PostManage = () => {
   if (status === "pending") return <h1>loading...</h1>;
   if (status === "error") return <h1>{error.message}</h1>;
 
+  const handleClickReviewsCnt = async (showId: string) => {
+    setOpenModal({ state: true, type: "" });
+    try {
+      const data = await getReviews(showId);
+      setReviewData(data);
+    } catch (e) {
+      // 에러 페이지 처리
+      console.error(e);
+    }
+  };
+
   return (
     <>
       <div className={styles["container"]}>
         <ul className={styles["list"]}>
           {showList.map((item) => (
             <li className={cx("list-row", "list-item")}>
-              <Link to={"/detail/3"} className={styles["list-row-left"]}>
+              <Link to={`/detail/${item.id}`} className={styles["list-row-left"]}>
                 <h3 className={cx("list-item__title", "ellipsis-multi")}>{item.title}</h3>
                 <p className={styles["list-item__date"]}>{item.start_date + " ~ " + item.end_date}</p>
               </Link>
               <div className={styles["list-row-right"]}>
                 <div className={styles["like-cnt"]}>
                   <LikeIcon />
-                  <span>{item.likes_count}</span>
+                  <span>
+                    {item.likes_count}
+                    <span className="a11y-hidden">개의 좋아요</span>
+                  </span>
                 </div>
-                <Button
-                  reverseColor={true}
-                  onClick={() => {
-                    setOpenModal({ state: true, type: "" });
-                  }}
-                  style={{ padding: "0.6rem" }}
-                >
+                <Button reverseColor={true} onClick={() => handleClickReviewsCnt(item.id.toString())} style={{ padding: "0.6rem" }}>
                   <CommentIcon className={styles["cmt-icon"]} />
-                  <span>{item.reviews_count}</span>
+                  <span>
+                    {item.reviews_count}
+                    <span className="a11y-hidden">개의 댓글</span>
+                  </span>
                 </Button>
                 <Button reverseColor={true} style={{ padding: "0.6rem" }} onClick={() => navigate("./update", { state: item.id })}>
                   수정/삭제
@@ -65,24 +80,18 @@ const PostManage = () => {
 
       {openModal.state && (
         <Modal title="서울대 어쩌고">
-          <strong className={styles["review-count"]}>총 후기수: 2명</strong>
+          <strong className={styles["review-count"]}>총 후기수: {reviewData.length}명</strong>
           <ul className={styles["review-list"]}>
-            {Array(5)
-              .fill(0)
-              .map(() => (
-                <li className={styles["review"]}>
-                  <div className={styles["review-contents"]}>
-                    <strong className={styles["review__nickname"]}>윤태현</strong>
-                    <p className={styles["review__content"]}>
-                      너무 좋았습니다.너무 좋았습니다.너무 좋았습니다.너무 좋았습니다.너무 좋았습니다.너무 좋았습니다.너무 좋았습니다.너무
-                      좋았습니다.너무 좋았습니다.너무 좋았습니다.너무 좋았습니다.너무 좋았습니다.너무 좋았습니다.너무 좋았습니다.너무 좋았습니다.너무
-                      좋았습니다.너무 좋았습니다.너무 좋았습니다.
-                    </p>
-                    <span className={styles["review__date"]}>2023-12-08</span>
-                  </div>
-                  <DeleteButton spanHidden="해당 댓글 삭제" onClick={() => console.log("댓글 삭제")} />
-                </li>
-              ))}
+            {reviewData.map((item) => (
+              <li className={styles["review"]}>
+                <div className={styles["review-contents"]}>
+                  <strong className={styles["review__nickname"]}>{item.login_id.slice(0, 3) + "***"}</strong>
+                  <p className={styles["review__content"]}>{item.comment}</p>
+                  <span className={styles["review__date"]}>{getElapsedTime(item.created_at)}</span>
+                </div>
+                <DeleteButton spanHidden="해당 댓글 삭제" onClick={() => console.log("댓글 삭제")} />
+              </li>
+            ))}
           </ul>
         </Modal>
       )}

--- a/src/components/mypage/PostManage/PostManage.tsx
+++ b/src/components/mypage/PostManage/PostManage.tsx
@@ -99,6 +99,7 @@ const PostManage = () => {
 
       {openModal.state && (
         <Modal title={openModal.type}>
+          {statusReviewList === "error" && <h1>{errorReviewList.message}</h1>}
           {statusReviewList !== "success" ? (
             <h1>loading...</h1>
           ) : (

--- a/src/components/mypage/PostManage/PostManage.tsx
+++ b/src/components/mypage/PostManage/PostManage.tsx
@@ -24,7 +24,7 @@ const PostManage = () => {
     data: showList,
     error: errorShowList,
   } = useQuery({
-    queryKey: ["showList", showId],
+    queryKey: ["showList"],
     queryFn: () => getMyShowList(),
   });
 
@@ -52,7 +52,6 @@ const PostManage = () => {
   const handleClickReviewsCnt = async (title: string, showId: string) => {
     setOpenModal({ state: true, type: title });
     setShowId(() => showId);
-    refetchReviews();
   };
 
   const handleClickDelete = (item: ReviewType) => () => {
@@ -65,7 +64,7 @@ const PostManage = () => {
       <div className={styles["container"]}>
         <ul className={styles["list"]}>
           {showList.map((item) => (
-            <li className={cx("list-row", "list-item")}>
+            <li className={cx("list-row", "list-item")} key={item}>
               <Link to={`/detail/${item.id}`} className={styles["list-row-left"]}>
                 <h3 className={cx("list-item__title", "ellipsis-multi")}>{item.title}</h3>
                 <p className={styles["list-item__date"]}>{item.start_date + " ~ " + item.end_date}</p>

--- a/src/components/mypage/PostManage/PostManage.tsx
+++ b/src/components/mypage/PostManage/PostManage.tsx
@@ -17,7 +17,6 @@ const PostManage = () => {
   const navigate = useNavigate();
   const { openModal, setOpenModal } = useModalStore();
   const [showId, setShowId] = useState<string>("");
-  const [selectedShowTitle, setSelectedShowTitle] = useState<string>("");
 
   // 게시글 리스트를 가져오는 쿼리
   const {
@@ -50,9 +49,8 @@ const PostManage = () => {
   if (statusShowList === "pending") return <h1>loading...</h1>;
   if (statusShowList === "error") return <h1>{errorShowList.message}</h1>;
 
-  const handleClickReviewsCnt = async (title, showId: string) => {
-    setOpenModal({ state: true, type: "" });
-    setSelectedShowTitle(title);
+  const handleClickReviewsCnt = async (title: string, showId: string) => {
+    setOpenModal({ state: true, type: title });
     setShowId(() => showId);
     refetchReviews();
   };
@@ -100,7 +98,7 @@ const PostManage = () => {
       </Button>
 
       {openModal.state && (
-        <Modal title={selectedShowTitle}>
+        <Modal title={openModal.type}>
           {statusReviewList !== "success" ? (
             <h1>loading...</h1>
           ) : (


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [x] 기능 추가 : 게시글 관리 페이지 기능 구현
- [x] 마크업 & 스타일 : 게시글 관리 페이지에 후기 리스트 모달창 내부 스타일 수정 
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [x] 도와주세요 : showId 키 값 제어
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

![게시글 관리 페이지](https://github.com/FESP-TEAM-1/beta-frontend/assets/90684277/0cd4a3ec-8573-4fbd-9724-b8abee6d9f9c)


<br>

## 🌟 전달 사항

- showId 상태관리 하는 방법 고민 중입니다
  - useQuery에 enabled 라는 옵션을 사용해서 댓글 리스트 GET요청을 조건부 실행을 하려고 합니다.
  - 지금 아래 코드(또는 여기 [PostManage.tsx](https://github.com/FESP-TEAM-1/beta-frontend/compare/feat/page-mypage-show-manage?expand=1#diff-b8600830903ba60d71ab426579dc2b85e46e790fbc93a4ba555067e0eebf16a9) 43번째줄)처럼 showId useState에 버튼을 누른 showId 값을 저장하고, 바뀐 상태값이 업데이트되고 나서야 refetchReviews()가 실행되는 상황인 것 같아요. 그래서 관리자 페이지가 처음 로드되고나서 제일 처음 후기 버튼을 누르면 아래 이미지처럼 첫 요청은 실패가되는 것 같아서 해당 문제 좀 더 고민해보고 수정해야할 것 같습니다. 첫 모달창이 뜨고 나서부터는 실패가 되진 않습니다. 좋은 의견있으면 말씀해주세요 ~~
   ```
  setShowId(() => showId);
   refetchReviews();
  ```
<img width="1437" alt="스크린샷 2023-12-20 오전 10 23 10" src="https://github.com/FESP-TEAM-1/beta-frontend/assets/90684277/89a03b78-f6e7-47e1-8c3a-d73169f60e39">


<br>

## ⚠️ Issue Number

- #45 

<br><br>
