### PR TITLE
feat/page-detail-reservation: 토스페이먼츠 결제 연동 및 예매 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@ckeditor/ckeditor5-react": "^6.2.0",
         "@ckeditor/ckeditor5-theme-lark": "^40.2.0",
         "@tanstack/react-query": "^5.12.2",
+        "@tosspayments/payment-widget-sdk": "^0.10.2",
         "@yaireo/tagify": "^4.17.9",
         "axios": "^1.6.2",
         "classnames": "^2.3.2",
@@ -2023,6 +2024,91 @@
       },
       "peerDependencies": {
         "react": "^18.0.0"
+      }
+    },
+    "node_modules/@tosspayments/payment__types": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@tosspayments/payment__types/-/payment__types-1.67.0.tgz",
+      "integrity": "sha512-e2W5AolyED1AA3uUaq27a8YQhrL7ZPNffIOF5qN2uP6RXIk6w1dtAFpY5tXBgLcyntYFMSKPCYevutUy8Ggc0g==",
+      "dependencies": {
+        "@tosspayments/sdk-constants": "^0.2.2"
+      }
+    },
+    "node_modules/@tosspayments/payment-widget__types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tosspayments/payment-widget__types/-/payment-widget__types-1.0.1.tgz",
+      "integrity": "sha512-p2l6ni4ZAH0Jh7Yo4hwwDAECN0rz6Io9R19oBJ5ZkL0H1upMhGzT6xrdymIYQwcUSzIcwHwI2u03eeAX19hmug==",
+      "dependencies": {
+        "@tosspayments/brandpay-types": "^0.2.6",
+        "@tosspayments/payment__types": "^1.66.3",
+        "@tosspayments/payment-widget-types": "^0.0.5"
+      }
+    },
+    "node_modules/@tosspayments/payment-widget__types/node_modules/@tosspayments/brandpay-types": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@tosspayments/brandpay-types/-/brandpay-types-0.2.6.tgz",
+      "integrity": "sha512-FY8aOm/2rqtXjYux9ZdNTL6GC5+VNIw8eOQ7TP01dS2uGWSzAtR6uuw9HVsgkmJtSyJgmo97tjmbio5oyeyFlg==",
+      "peerDependencies": {
+        "typescript": "^4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tosspayments/payment-widget__types/node_modules/@tosspayments/payment-widget-types": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@tosspayments/payment-widget-types/-/payment-widget-types-0.0.5.tgz",
+      "integrity": "sha512-Daaui9u7aRPzJhw4omJIUAbYBSmNAFNjWWkuUnX9uHxzE3gtjcJHIpGrjlzmCFm+j3ZH4rgyrgv4pkazVYH3OQ==",
+      "peerDependencies": {
+        "typescript": "^4.7.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tosspayments/payment-widget__types/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@tosspayments/payment-widget-sdk": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tosspayments/payment-widget-sdk/-/payment-widget-sdk-0.10.2.tgz",
+      "integrity": "sha512-0dpkEbnDXmvIwpHYm+YODpMhh/gAtvJRYOU5uikFQpM/XCkyZDXAP9C6pc+GhiT6NsWIKKFILwaSgAeL/UT3ow==",
+      "dependencies": {
+        "@tosspayments/payment-widget__types": "1.0.1"
+      }
+    },
+    "node_modules/@tosspayments/sdk-constants": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@tosspayments/sdk-constants/-/sdk-constants-0.2.2.tgz",
+      "integrity": "sha512-qTIcD9JnVtN65/yiW5sPAlvK5fpQtDluv4IEyslubncbQLQKE+ePSnGZU1fLNPxcchv6QTnwmgj9Ndm6EN/Ymg==",
+      "dependencies": {
+        "type-fest": "^2.11.2"
+      }
+    },
+    "node_modules/@tosspayments/sdk-constants/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@ckeditor/ckeditor5-react": "^6.2.0",
     "@ckeditor/ckeditor5-theme-lark": "^40.2.0",
     "@tanstack/react-query": "^5.12.2",
+    "@tosspayments/payment-widget-sdk": "^0.10.2",
     "@yaireo/tagify": "^4.17.9",
     "axios": "^1.6.2",
     "classnames": "^2.3.2",

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,6 +1,6 @@
 import { createBrowserRouter } from "react-router-dom";
 import App from "./App";
-import { LoginPage, SignupPage, MainPage, MainConcertPage, DetailPage, ErrorPage, MainExhibitionPage } from "@/pages";
+import { LoginPage, SignupPage, MainPage, MainConcertPage, DetailPage, ErrorPage, MainExhibitionPage, PaySuccessPage, PayFailPage } from "@/pages";
 import { InfoSection, ReviewSection } from "@/components/detail";
 import Mypage from "@/pages/Mypage/Mypage";
 import { Profile, LikeManage, ReviewManage, StoryManage, Reservation, ReservationManage, PostManage, PostUpload } from "@/components/mypage";
@@ -82,6 +82,19 @@ const router = createBrowserRouter([
           {
             path: "post/upload",
             element: <PostUpload />,
+          },
+        ],
+      },
+      {
+        path: "/payment",
+        children: [
+          {
+            path: "success",
+            element: <PaySuccessPage />,
+          },
+          {
+            path: "fail",
+            element: <PayFailPage />,
           },
         ],
       },

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -13,6 +13,7 @@ import deleteReview from "./deleteReview";
 import patchReview from "./patchReview";
 import postLike from "./postLike";
 import deleteLike from "./deleteLike";
+import postReservation from "./postReservation";
 
 export {
   getShows,
@@ -29,4 +30,5 @@ export {
   patchReview,
   postLike,
   deleteLike,
+  postReservation,
 };

--- a/src/apis/postReservation.ts
+++ b/src/apis/postReservation.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+
+interface PostReservationParamType {
+  orderId?: string;
+  amount?: string;
+  show_id: number;
+  show_times_id: number;
+  is_receive_email: 1 | 0;
+}
+
+const postReservation = async (data: PostReservationParamType) => {
+  try {
+    await axios.post("/api/confirm", data);
+  } catch (err) {
+    throw "서버 요청 실패";
+  }
+};
+
+export default postReservation;

--- a/src/assets/checkbox-payment.svg
+++ b/src/assets/checkbox-payment.svg
@@ -1,0 +1,4 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="40" cy="40" r="40" fill="#DA3017"/>
+<path d="M58 28L36.8235 53L22 37.0909" stroke="white" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/detail/ReservationForm/ReservationForm.module.css
+++ b/src/components/detail/ReservationForm/ReservationForm.module.css
@@ -1,3 +1,7 @@
+.reservation-section * {
+  box-sizing: border-box;
+}
+
 .show-info,
 .show-notice,
 .show-round,

--- a/src/components/detail/ReservationForm/ReservationForm.tsx
+++ b/src/components/detail/ReservationForm/ReservationForm.tsx
@@ -1,56 +1,47 @@
-import { useQuery } from "@tanstack/react-query";
 import { Button, CheckBox, InputField, InputFieldGroup, RadioButtonGroup } from "@/components/common";
 import useInputs from "@/hooks/useInputs";
-import { getUserInfo } from "@/apis";
-import { UserReservationFormType, ShowReservationInfoType, UserReservationInputsType } from "@/types";
-import styles from "./ReservationFormModal.module.css";
-
-// TODO: show_times API 연결
-const show_times_data = ["2023/12/08 - 오후 1시", "2023/12/08 - 오후 7시", "2023/12/10 - 오후 1시", "2023/12/10 - 오후 7시"];
+import { UserReservationFormType, UserReservationInputsType, AgencyReservationInfoType, MemberType } from "@/types";
+import styles from "./ReservationForm.module.css";
 
 interface PropsType {
-  showReservationInfo: Omit<ShowReservationInfoType, "method" | "google_form_url">;
+  showInfo: AgencyReservationInfoType;
+  userInfo: MemberType;
+  goToPaymentStep: () => void;
 }
 
-const ReservationFormModal: React.FC<PropsType> = ({ showReservationInfo }) => {
+const ReservationForm: React.FC<PropsType> = ({ showInfo, userInfo, goToPaymentStep }) => {
   const [form, onChange] = useInputs<UserReservationInputsType>({
     show_times_id: 0,
     is_receive_email: false,
   });
 
-  const {
-    status,
-    error,
-    data: userInfo,
-  } = useQuery({
-    queryKey: ["userInfo"],
-    queryFn: () => getUserInfo("yoonth0919"), // TODO: 로그인 정보에서 아이디 값 가져오기
-  });
+  const { location, price, notice, date_time } = showInfo;
+  const show_date_time = date_time.map((item) => item.date_time);
 
-  if (status === "pending") return <h1>loading...</h1>;
-  if (status === "error") return <h1>{error.message}</h1>;
-
-  const { location, price, notice } = showReservationInfo;
   const { user_name, user_email, phone_number } = userInfo;
-
   const [email1, email2] = user_email.split("@");
   const [phone1, phone2, phone3] = phone_number.split("-");
-  const noticeBufferData = new Uint8Array(notice.data);
-  const noticeDecodedString = new TextDecoder("utf-8").decode(noticeBufferData);
+  const noticeBufferData = notice && new Uint8Array(notice.data);
+  const noticeDecodedString = noticeBufferData && new TextDecoder("utf-8").decode(noticeBufferData);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const result: UserReservationFormType = {
       user_id: userInfo.id,
-      show_id: showReservationInfo.show_id,
+      show_id: showInfo.show_id,
       show_times_id: form.show_times_id,
       is_receive_email: form.is_receive_email ? 1 : 0,
     };
-    console.log(result);
+    if (price === 0) {
+      //  post 요청
+      return;
+    }
+
+    goToPaymentStep();
   };
 
   return (
-    <section className={styles["reservation-section"]}>
+    <>
       <div className={styles["show-info"]}>
         <h2>공연 정보</h2>
         <p>
@@ -71,7 +62,7 @@ const ReservationFormModal: React.FC<PropsType> = ({ showReservationInfo }) => {
       <form id="reservation" onSubmit={handleSubmit}>
         <div className={styles["show-round"]}>
           <h2>회차 선택</h2>
-          <RadioButtonGroup radioList={show_times_data} name="round" onChange={onChange} flexDirectionColumn />
+          <RadioButtonGroup radioList={show_date_time} name="round" onChange={onChange} flexDirectionColumn />
         </div>
 
         <div className={styles["show-reservation-user-info"]}>
@@ -88,8 +79,20 @@ const ReservationFormModal: React.FC<PropsType> = ({ showReservationInfo }) => {
         </div>
       </form>
 
-      {/* TODO: show_sub_type일때  */}
-      {/* {show_sub_type === "연극" && (
+      <Button type="submit" form="reservation">
+        예매하기
+      </Button>
+    </>
+  );
+};
+
+export default ReservationForm;
+
+{
+  /* TODO: show_sub_type일때  */
+}
+{
+  /* {show_sub_type === "연극" && (
         <div className={styles["show-agreement"]}>
           <h2 className="a11y-hidden">동의서</h2>
           <CheckBox inputId="외부 유출 금지 동의">
@@ -102,13 +105,5 @@ const ReservationFormModal: React.FC<PropsType> = ({ showReservationInfo }) => {
             <span>*노쇼 (NO SHOW)및 무단양도 관객의 경우 다음 oo대학교 oo학과 공연 예매가 제한 될 수 있음을 안내드립니다.</span>
           </CheckBox>
         </div>
-      )} */}
-
-      <Button type="submit" form="reservation">
-        예매하기
-      </Button>
-    </section>
-  );
-};
-
-export default ReservationFormModal;
+      )} */
+}

--- a/src/components/detail/ReservationModal/ReservationModal.module.css
+++ b/src/components/detail/ReservationModal/ReservationModal.module.css
@@ -1,0 +1,3 @@
+.reservation-section * {
+  box-sizing: border-box;
+}

--- a/src/components/detail/ReservationModal/ReservationModal.tsx
+++ b/src/components/detail/ReservationModal/ReservationModal.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { ReservationForm, ReservationPayment } from "..";
+import { useLoginStore } from "@/stores/useLoginStore";
+import { AgencyReservationInfoType } from "@/types";
+import { getUserInfo } from "@/apis";
+import styles from "./ReservationModal.module.css";
+
+interface PropsType {
+  agencyReservationInfo: AgencyReservationInfoType;
+}
+const ReservationModal: React.FC<PropsType> = ({ agencyReservationInfo }) => {
+  const [step, setStep] = useState("form");
+
+  const goToPaymentStep = () => {
+    setStep("payment");
+  };
+
+  const {
+    userState: { login_id },
+  } = useLoginStore();
+  const {
+    status,
+    error,
+    data: userInfo,
+  } = useQuery({
+    queryKey: ["userInfo"],
+    queryFn: () => getUserInfo(login_id),
+  });
+
+  if (status === "pending") return <h1>loading...</h1>;
+  if (status === "error") return <h1>{error.message}</h1>;
+
+  return (
+    <section className={styles["reservation-section"]}>
+      {step === "form" && <ReservationForm showInfo={agencyReservationInfo} userInfo={userInfo} goToPaymentStep={goToPaymentStep} />}
+
+      {step === "payment" && <ReservationPayment showInfo={agencyReservationInfo} userInfo={userInfo} />}
+    </section>
+  );
+};
+
+export default ReservationModal;

--- a/src/components/detail/ReservationPayment/ReservationPayment.tsx
+++ b/src/components/detail/ReservationPayment/ReservationPayment.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from "react";
+import { PaymentWidgetInstance, loadPaymentWidget } from "@tosspayments/payment-widget-sdk";
+import { useQuery } from "@tanstack/react-query";
+import { nanoid } from "nanoid";
+import { AgencyReservationInfoType, MemberType } from "@/types";
+import "./style.css";
+
+const selector = "#payment-widget";
+const clientKey = import.meta.env.VITE_APP_TOSS_PAYMENTS_CLIENT_KEY as string;
+const customerKey = nanoid();
+
+interface PropsType {
+  showInfo: AgencyReservationInfoType;
+  userInfo: MemberType;
+}
+
+const ReservationPayment: React.FC<PropsType> = ({ showInfo, userInfo }) => {
+  const { price, title } = showInfo;
+  const { user_name, user_email, phone_number } = userInfo;
+
+  const { data: paymentWidget } = usePaymentWidget(clientKey, customerKey);
+  const paymentMethodsWidgetRef = useRef<ReturnType<PaymentWidgetInstance["renderPaymentMethods"]> | null>(null);
+
+  useEffect(() => {
+    if (paymentWidget == null) {
+      return;
+    }
+    const paymentMethodsWidget = paymentWidget.renderPaymentMethods(selector, { value: price! }, { variantKey: "DEFAULT" }); // 결제위젯 렌더링
+    paymentWidget.renderAgreement("#agreement", { variantKey: "AGREEMENT" }); // 이용약관 렌더링
+    paymentMethodsWidgetRef.current = paymentMethodsWidget;
+  }, [paymentWidget]);
+
+  useEffect(() => {
+    const paymentMethodsWidget = paymentMethodsWidgetRef.current;
+    if (paymentMethodsWidget == null) {
+      return;
+    }
+    paymentMethodsWidget.updateAmount(price!); // 금액 업데이트
+  }, [price]);
+
+  return (
+    <div className="wrapper w-100">
+      <div className="w-100">
+        <div id="payment-widget" className="w-100" />
+        <div id="agreement" className="w-100" />
+        <div className="btn-wrapper w-100">
+          <p className="test-payment">실제로 금액이 빠져나가지 않는 테스트에요</p>
+          <button
+            className="btn primary w-100"
+            onClick={async () => {
+              try {
+                // '결제하기' 버튼 누르면 결제창 띄우기
+                await paymentWidget?.requestPayment({
+                  orderId: nanoid(),
+                  orderName: title,
+                  customerName: user_name,
+                  customerEmail: user_email,
+                  customerMobilePhone: phone_number,
+                  successUrl: `${window.location.origin}/payment/success`,
+                  failUrl: `${window.location.origin}/payment/fail`,
+                });
+              } catch (error) {
+                // 에러 처리하기
+                console.error(error);
+              }
+            }}
+          >
+            결제하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ReservationPayment;
+
+const usePaymentWidget = (clientKey: string, customerKey: string) => {
+  return useQuery({
+    queryKey: ["payment-widget", clientKey, customerKey],
+    queryFn: () => {
+      // 결제위젯 초기화
+      return loadPaymentWidget(clientKey, customerKey);
+    },
+  });
+};

--- a/src/components/detail/ReservationPayment/ReservationPayment.tsx
+++ b/src/components/detail/ReservationPayment/ReservationPayment.tsx
@@ -55,7 +55,7 @@ const ReservationPayment: React.FC<PropsType> = ({ showInfo, userInfo }) => {
                   orderName: title,
                   customerName: user_name,
                   customerEmail: user_email,
-                  customerMobilePhone: phone_number,
+                  customerMobilePhone: phone_number.replace(/-/g, ""),
                   successUrl: `${window.location.origin}/payment/success`,
                   failUrl: `${window.location.origin}/payment/fail`,
                 });

--- a/src/components/detail/ReservationPayment/style.css
+++ b/src/components/detail/ReservationPayment/style.css
@@ -1,0 +1,147 @@
+.w-100 {
+  width: 100%;
+}
+
+.h-100 {
+  height: 100%;
+}
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow: auto;
+}
+
+.max-w-540 {
+  max-width: 540px;
+}
+
+.test-payment {
+  margin-bottom: 10px;
+  color: #3282f6;
+  font-size: 15px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.btn-wrapper {
+  padding: 0 24px;
+}
+
+.btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 11px 22px;
+  border: none;
+  border-radius: 8px;
+  background-color: #f2f4f6;
+  color: #4e5968;
+  font-weight: 600;
+  font-size: 17px;
+  cursor: pointer;
+  word-break: break-all;
+}
+
+.btn.primary {
+  background-color: #3282f6;
+  color: #f9fcff;
+}
+
+.btn.red {
+  background-color: var(--main-color);
+  color: white;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.flex {
+  display: flex;
+}
+
+.flex-column {
+  display: flex;
+  flex-direction: column;
+}
+
+.justify-center {
+  justify-content: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}
+
+.align-center {
+  align-items: center;
+}
+
+.confirm-loading {
+  margin-top: 72px;
+  height: 400px;
+  justify-content: space-between;
+}
+
+.confirm-success {
+  display: none;
+  margin-top: 72px;
+}
+
+.button-group {
+  margin-top: 32px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 16px;
+}
+
+.title {
+  margin-top: 32px;
+  margin-bottom: 0;
+  color: #191f28;
+  font-weight: bold;
+  font-size: 24px;
+}
+
+.description {
+  margin-top: 8px;
+  color: #4e5968;
+  font-size: 17px;
+  font-weight: 500;
+}
+
+.response-section {
+  margin-top: 60px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  font-size: 20px;
+}
+
+.response-section .response-label {
+  font-weight: 600;
+  color: #333d48;
+  font-size: 17px;
+}
+
+.response-section .response-text {
+  font-weight: 500;
+  color: #4e5968;
+  font-size: 17px;
+  padding-left: 16px;
+  word-break: break-word;
+  text-align: right;
+}
+
+.color-grey {
+  color: #b0b8c1;
+}
+
+.responsive {
+  width: calc(100% - 30px);
+  margin: auto;
+  padding: 20px 0;
+}

--- a/src/components/detail/index.tsx
+++ b/src/components/detail/index.tsx
@@ -6,7 +6,9 @@ import ReviewSection from "./ReviewSection/ReviewSection";
 import ReviewForm from "./ReviewForm/ReviewForm";
 import ReviewItem from "./ReviewItem/ReviewItem";
 import GuestAccess from "./GuestAccess/GuestAccess";
-import ReservationFormModal from "./ReservationFormModal/ReservationFormModal";
+import ReservationModal from "./ReservationModal/ReservationModal";
+import ReservationForm from "./ReservationForm/ReservationForm";
+import ReservationPayment from "./ReservationPayment/ReservationPayment";
 import ReviewEditForm from "./ReviewEditForm/ReviewEditForm";
 
 export {
@@ -18,6 +20,8 @@ export {
   ReviewForm,
   ReviewItem,
   GuestAccess,
-  ReservationFormModal,
+  ReservationModal,
+  ReservationForm,
+  ReservationPayment,
   ReviewEditForm,
 };

--- a/src/hooks/useInputs.tsx
+++ b/src/hooks/useInputs.tsx
@@ -1,5 +1,5 @@
 import { FormInputs } from "@/types";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 
 const objectTypeNames = ["phone", "email"];
 
@@ -14,6 +14,11 @@ const useInputs = <T extends FormInputs>(initialForm: T): UseInputs<T> => {
 
     if (type === "checkbox") {
       setForm((form) => ({ ...form, [name]: e.target.checked }));
+      return;
+    }
+
+    if (type === "radio" && name === "show_times_id") {
+      setForm((form) => ({ ...form, [name]: Number(value) }));
       return;
     }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,18 +12,18 @@ import "./global.css";
 export const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-      <ToastContainer
-        position="top-center"
-        autoClose={1000}
-        hideProgressBar={false}
-        closeOnClick={true}
-        pauseOnHover={true}
-        draggable={true}
-        theme="light"
-      />
-    </QueryClientProvider>
-  </React.StrictMode>,
+  // <React.StrictMode>
+  <QueryClientProvider client={queryClient}>
+    <RouterProvider router={router} />
+    <ToastContainer
+      position="top-center"
+      autoClose={1000}
+      hideProgressBar={false}
+      closeOnClick={true}
+      pauseOnHover={true}
+      draggable={true}
+      theme="light"
+    />
+  </QueryClientProvider>,
+  // </React.StrictMode>,
 );

--- a/src/pages/PayFail/PayFailPage.tsx
+++ b/src/pages/PayFail/PayFailPage.tsx
@@ -1,6 +1,8 @@
+import { useReservationFormStore } from "@/stores/useReservationFormStore";
 import { Link, useSearchParams } from "react-router-dom";
 
 const PayFailPage = () => {
+  const { reservationForm } = useReservationFormStore();
   const [searchParams] = useSearchParams();
   const errorCode = searchParams.get("code");
   const errorMessage = searchParams.get("message");
@@ -27,8 +29,8 @@ const PayFailPage = () => {
 
         <div className="w-100 button-group">
           <div className="flex" style={{ gap: "16px" }}>
-            <Link to="/" className="btn w-100">
-              홈으로
+            <Link to={`/detail/${reservationForm?.show_id}`} className={"btn w-100"}>
+              뒤로 가기
             </Link>
             <Link to="/" className={"btn w-100 red"}>
               홈으로 이동

--- a/src/pages/PayFail/PayFailPage.tsx
+++ b/src/pages/PayFail/PayFailPage.tsx
@@ -1,0 +1,43 @@
+import { Link, useSearchParams } from "react-router-dom";
+
+const PayFailPage = () => {
+  const [searchParams] = useSearchParams();
+  const errorCode = searchParams.get("code");
+  const errorMessage = searchParams.get("message");
+
+  return (
+    <div className="wrapper w-100">
+      <div className="flex-column align-center  max-w-540 responsive">
+        <img src="https://static.toss.im/lotties/error-spot-apng.png" width="120" height="120" />
+        <h2 className="title">결제를 실패했어요</h2>
+        <div className="response-section w-100">
+          <div className="flex justify-between">
+            <span className="response-label">code</span>
+            <span id="error-code" className="response-text">
+              {errorCode}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span className="response-label">message</span>
+            <span id="error-message" className="response-text">
+              {errorMessage}
+            </span>
+          </div>
+        </div>
+
+        <div className="w-100 button-group">
+          <div className="flex" style={{ gap: "16px" }}>
+            <Link to="/" className="btn w-100">
+              홈으로
+            </Link>
+            <Link to="/" className={"btn w-100 red"}>
+              홈으로 이동
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PayFailPage;

--- a/src/pages/PaySuccess/PaySuccessPage.tsx
+++ b/src/pages/PaySuccess/PaySuccessPage.tsx
@@ -1,0 +1,76 @@
+import { useEffect } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import CheckBoxIconSrc from "@/assets/checkbox-payment.svg";
+import axios from "axios";
+
+const PaySuccessPage = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    const requestData = {
+      orderId: searchParams.get("orderId"),
+      amount: searchParams.get("amount"),
+      paymentKey: searchParams.get("paymentKey"),
+    };
+
+    const secretKey = import.meta.env.TOSS_PAYMENTS_SECRET_KEY as string;
+    const encryptedSecretKey = `Basic ${btoa(secretKey + ":")}`;
+
+    const confirm = async () => {
+      const { data, status } = await axios.post("https://api.tosspayments.com/v1/payments/confirm", requestData, {
+        headers: {
+          Authorization: encryptedSecretKey,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (status !== 200) {
+        navigate(`/payment/fail?code=${data.code}&message=${data.message}`);
+        return;
+      }
+    };
+    confirm();
+  }, []);
+
+  return (
+    <div className="wrapper w-100">
+      <div
+        className="flex-column align-center confirm-success max-w-540 responsive"
+        style={{
+          display: "flex",
+        }}
+      >
+        <img src={CheckBoxIconSrc} width="120" height="120" />
+        <h2 className="title">결제를 완료했어요</h2>
+        <div className="response-section w-100">
+          <div className="flex justify-between">
+            <span className="response-label">결제 금액</span>
+            <span id="amount" className="response-text">
+              {Number(searchParams.get("amount")).toLocaleString()}원
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span className="response-label">주문번호</span>
+            <span id="orderId" className="response-text">
+              {searchParams.get("orderId")}
+            </span>
+          </div>
+        </div>
+
+        <div className="w-100 button-group">
+          <div className="flex" style={{ gap: "16px" }}>
+            <Link to="/mypage/reservation" className="btn w-100 ">
+              마이페이지에서 확인
+            </Link>
+            <Link to="/" className="btn w-100 red">
+              홈으로 이동
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PaySuccessPage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,5 +5,7 @@ import MainConcertPage from "./MainConcert/MainConcertPage";
 import MainExhibitionPage from "./MainExhibition/MainExhibitionPage";
 import DetailPage from "./Detail/DetailPage";
 import ErrorPage from "./Error/ErrorPage";
+import PaySuccessPage from "./PaySuccess/PaySuccessPage";
+import PayFailPage from "./PayFail/PayFailPage";
 
-export { LoginPage, SignupPage, MainPage, MainConcertPage, MainExhibitionPage, DetailPage, ErrorPage };
+export { LoginPage, SignupPage, MainPage, MainConcertPage, MainExhibitionPage, DetailPage, ErrorPage, PaySuccessPage, PayFailPage };

--- a/src/stores/useReservationFormStore.ts
+++ b/src/stores/useReservationFormStore.ts
@@ -1,0 +1,23 @@
+import { UserReservationFormType } from "@/types";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface useReservationFormStoreType {
+  reservationForm: UserReservationFormType | null;
+  setReservationForm: (item: UserReservationFormType) => void;
+}
+
+export const useReservationFormStore = create(
+  persist<useReservationFormStoreType>(
+    (set) => ({
+      reservationForm: null,
+      setReservationForm: (data) =>
+        set(() => ({
+          reservationForm: data,
+        })),
+    }),
+    {
+      name: "reservation-form-storage",
+    },
+  ),
+);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 import { ShowResponseType, ShowType, ShowFilterRequestType } from "./showType";
 import { StoryResponseType, StoryType } from "./storyType";
-import { ShowReservationInfoType, ShowReservationInfoResponseType } from "./showReservationInfoType";
+import { ShowReservationInfoResponseType, ShowReservationInfoType, AgencyReservationInfoType } from "./showReservationInfoType";
 import { UserReservationFormType, UserReservationInputsType } from "./userReservationFormType";
 import { MemberResponseType, MemberType } from "./memberType";
 import { DateInputType, DateWithTime } from "./datePickerInputType";
@@ -15,6 +15,7 @@ export {
   type StoryType,
   type ShowReservationInfoResponseType,
   type ShowReservationInfoType,
+  type AgencyReservationInfoType,
   type UserReservationInputsType,
   type UserReservationFormType,
   type MemberType,

--- a/src/types/showReservationInfoType.ts
+++ b/src/types/showReservationInfoType.ts
@@ -6,14 +6,25 @@ export interface ShowReservationInfoResponseType {
 export interface ShowReservationInfoType {
   id: number;
   show_id: number;
-  method: string | null;
-  google_form_url: string | null;
+  method: "google" | "agency";
+  google_form_url: null | string;
   location: string;
   location_detail: string | null;
   position: string;
   price: number | null;
   head_count: number | null;
   notice: Notice | null;
+  date_time: ShowDateTime[];
+  title: string;
+}
+
+export type AgencyReservationInfoType = Omit<ShowReservationInfoType, "method" | "google_form_url">;
+
+interface ShowDateTime {
+  id: number;
+  show_id: number;
+  date_time: string;
+  head_count: number;
 }
 
 export interface Notice {

--- a/src/types/userReservationFormType.ts
+++ b/src/types/userReservationFormType.ts
@@ -5,8 +5,7 @@ export interface UserReservationInputsType {
 }
 
 export interface UserReservationFormType {
-  user_id: number;
   show_id: number;
   show_times_id: number;
-  is_receive_email: number;
+  is_receive_email: 1 | 0;
 }


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [x] 기능 추가 : 결제 위젯 연동, 결제성공페이지/실패페이지 마크업 및 기능 구현 
- [ ] 마크업 & 스타일 : 
- [x] 리팩토링 : FormModal에서 Form 부분 컴포넌트화 
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

![ezgif-3-87e28343af](https://github.com/FESP-TEAM-1/beta-frontend/assets/75666099/f921954d-c119-4398-a7c0-d82c99bfd7d8)

<br>

## 🌟 전달 사항

- strict 모드일때 결제를 두번해서 안되어서 **strict모드 주석처리했습니다.**
- 그런데 toss payments api key가 개발자 모드에서 볼 수 있는 것 때문에 백엔드에서 결제 해야할 것 같다고 태현님께서 말씀해주셨습니다. 지금 이상태로 두고 추후에 바꾸면 좋을 것 같습니다.
- 토스페이먼츠는 0원 결제는 안되기 때문에 0원일때는 예매 api 요청만 보내고, **0원 결제가 아닐때에는 토스페이먼츠에 결제요청을하고 성공했을 시 예매 api 요청을 보냅니다.** 
- 토스페이먼츠 결제 요청을 성공했는데 예매 api 요청이 실패했을 시 앞서 진행했던 결제를 취소해야합니다. 어차피 **백엔드에서 토스페이먼츠 결제요청을 하는 걸로 바뀔 것이기 때문에 토스페이먼츠 결제 성공했지만 예매 api 요청 실패했을때 앞서 진행했던 결제를 취소하는 로직은 구현하지 않았습니다.**
- 백엔드에서 토스페이먼츠 결제 요청하는 걸로 바뀌면 strict 모드 주석했던거 주석해제 할 수 있게 됩니다!

<br>

- Todo
- [ ] 0원일때 예매 실패했으면 toast 알람 띄우기
- [ ] 이미 예매한 쇼일때 예매 안되게 버튼 disabled 시키고, 버튼 클릭시 이미 예매해서 예매 못한다고 알람 띄우기
 

<br>

## ⚠️ Issue Number

- #61 

<br><br>
