### PR TITLE
feat/page-mypage-show-manage: 관리자 후기 삭제 모달창 닫으면 게시글 리스트 업데이트 기능 추가

### DIFF
--- a/src/apis/deleteReviewAdmin.ts
+++ b/src/apis/deleteReviewAdmin.ts
@@ -1,0 +1,14 @@
+import axios from "axios";
+import { ReviewDeleteParamType } from "@/types";
+
+interface ReviewDeleteResponse {
+  ok: boolean;
+  data: boolean;
+}
+
+const deleteReviewAdmin = async (review: ReviewDeleteParamType) => {
+  const { review_id, show_id } = review;
+  await axios.delete<ReviewDeleteResponse>(`/api/show/review/admin/delete/${review_id}/${show_id}`);
+};
+
+export default deleteReviewAdmin;

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -18,6 +18,7 @@ import deleteShow from "./deleteShow";
 import postReservation from "./postReservation";
 import getUserReviewList from "./getUserReviewList";
 import getMyShowList from "./getMyShowList";
+import deleteReviewAdmin from "./deleteReviewAdmin";
 
 export {
   getShows,
@@ -40,4 +41,5 @@ export {
   deleteShow,
   getUserReviewList,
   getMyShowList,
+  deleteReviewAdmin,
 };

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -4,6 +4,7 @@ import { useModalStore } from "@/stores/useModalStore";
 import { usePreventScroll } from "@/hooks";
 import classNames from "classnames/bind";
 import styles from "./Modal.module.css";
+import { queryClient } from "@/main";
 
 const cx = classNames.bind(styles);
 
@@ -16,7 +17,7 @@ interface PropsType {
 }
 
 const Modal: React.FC<PropsType> = ({ children, width, height, title, titleHidden = false }) => {
-  const { setOpenModal } = useModalStore();
+  const { openModal, setOpenModal } = useModalStore();
 
   usePreventScroll();
 
@@ -24,6 +25,9 @@ const Modal: React.FC<PropsType> = ({ children, width, height, title, titleHidde
     const targetClassName = (e.target as HTMLElement).className;
 
     if (targetClassName.includes("modal-background") || targetClassName.includes("modal__close")) {
+      if (openModal.type === "reivewManage") {
+        queryClient.fetchQuery({ queryKey: ["showList"] });
+      }
       setOpenModal({ state: false, type: "" });
     }
   };

--- a/src/components/mypage/PostManage/PostManage.tsx
+++ b/src/components/mypage/PostManage/PostManage.tsx
@@ -7,9 +7,10 @@ import classNames from "classnames/bind";
 import styles from "./PostManage.module.css";
 import LikeIcon from "@/assets/like.svg?react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { deleteReview, getMyShowList, getReviews } from "@/apis";
+import { deleteReviewAdmin, getMyShowList, getReviews } from "@/apis";
 import { ReviewDeleteParamType, ReviewType } from "@/types";
 import getElapsedTime from "@/utils/getElapsedTime";
+import { toast } from "react-toastify";
 
 const cx = classNames.bind(styles);
 
@@ -17,6 +18,7 @@ const PostManage = () => {
   const navigate = useNavigate();
   const { openModal, setOpenModal } = useModalStore();
   const [showId, setShowId] = useState<string>("");
+  const [showTitle, setShowTitle] = useState<string>("");
 
   // 게시글 리스트를 가져오는 쿼리
   const {
@@ -42,16 +44,18 @@ const PostManage = () => {
 
   // 후기 삭제를 위한 뮤테이션
   const { mutate: deleteMutate } = useMutation({
-    mutationFn: (review: ReviewDeleteParamType) => deleteReview(review),
+    mutationFn: (review: ReviewDeleteParamType) => deleteReviewAdmin(review),
     onSuccess: () => refetchReviews(),
+    onError: () => toast.error("댓글 삭제 실패"),
   });
 
   if (statusShowList === "pending") return <h1>loading...</h1>;
   if (statusShowList === "error") return <h1>{errorShowList.message}</h1>;
 
   const handleClickReviewsCnt = async (title: string, showId: string) => {
-    setOpenModal({ state: true, type: title });
+    setOpenModal({ state: true, type: "reivewManage" });
     setShowId(() => showId);
+    setShowTitle(() => title);
   };
 
   const handleClickDelete = (item: ReviewType) => () => {
@@ -66,7 +70,7 @@ const PostManage = () => {
       <div className={styles["container"]}>
         <ul className={styles["list"]}>
           {showList.map((item) => (
-            <li className={cx("list-row", "list-item")} key={item}>
+            <li className={cx("list-row", "list-item")}>
               <Link to={`/detail/${item.id}`} className={styles["list-row-left"]}>
                 <h3 className={cx("list-item__title", "ellipsis-multi")}>{item.title}</h3>
                 <p className={styles["list-item__date"]}>{item.start_date + " ~ " + item.end_date}</p>
@@ -99,7 +103,7 @@ const PostManage = () => {
       </Button>
 
       {openModal.state && (
-        <Modal title={openModal.type}>
+        <Modal title={showTitle}>
           {statusReviewList === "error" && <h1>{errorReviewList.message}</h1>}
           {statusReviewList !== "success" ? (
             <h1>loading...</h1>
@@ -108,8 +112,8 @@ const PostManage = () => {
               <strong className={styles["review-count"]}>총 후기수: {reviewList.length}명</strong>
               {reviewList.length ? (
                 <ul className={styles["review-list"]}>
-                  {reviewList.map((item) => (
-                    <li className={styles["review"]}>
+                  {reviewList.map((item, index) => (
+                    <li className={styles["review"]} key={index}>
                       <div className={styles["review-contents"]}>
                         <strong className={styles["review__nickname"]}>{item.login_id.slice(0, 3) + "***"}</strong>
                         <p className={styles["review__content"]}>{item.comment}</p>


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [x] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

- 관리자가 마이페이지에서 게시글 후기 모달창을 열었다가 닫으면 후기수 업데이트를 위해 게시글 리스트를 다시 불러오는 기능입니다

![댓글](https://github.com/FESP-TEAM-1/beta-frontend/assets/90684277/34b377f1-0c6d-4246-8745-1525ed6c45e2)


<br>

## 🌟 전달 사항

-

<br>

## ⚠️ Issue Number

- #45 

<br><br>
