### PR TITLE
fix/filters: 메인 공연페이지 카테고리 필더 제대로 동작 안하는 버그 고침

### DIFF
--- a/src/components/common/Filters/Filters.tsx
+++ b/src/components/common/Filters/Filters.tsx
@@ -90,13 +90,13 @@ const Filters: React.FC<PropsType> = ({ filterRequest, setFilterRequest }) => {
     setFilterRequest({ ...filterRequest, progress: progressStatus });
   };
 
-  //  location을 all, 강남구, ..., 중랑구로 set하는 함수
-  const locationSetFunc = (value: string) => {
+  // date, progress를 제외한 나머지 항목 set하는 함수
+  const etcSetFunc = (name: string, value: string) => {
     if (value === "전체") {
-      setFilterRequest({ ...filterRequest, location: "all" });
+      setFilterRequest({ ...filterRequest, [name]: "all" });
       return;
     }
-    setFilterRequest({ ...filterRequest, location: value });
+    setFilterRequest({ ...filterRequest, [name]: value });
   };
 
   // FilterButton을 눌렀을 때 동작하는 함수
@@ -106,10 +106,8 @@ const Filters: React.FC<PropsType> = ({ filterRequest, setFilterRequest }) => {
       dateSetFunc(value!);
     } else if (name === "progress") {
       progressSetFunc(value!);
-    } else if (name === "location") {
-      locationSetFunc(value!);
     } else {
-      setFilterRequest({ ...filterRequest, [name]: value });
+      etcSetFunc(name, value!);
     }
     setFilter((prev) => ({ ...prev, [name]: value }));
   };


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [ ] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

- 메인 공연페이지에서 category를 all, 음악, 연극, 기타로 보내야하는데 전체, 음악, 연극, 기타로 보내서 전체 버튼을 눌렀을 때 공연리스트를 불러오지 못하는 버그 발견하여 수정하였습니다.

<br>

## 🌟 전달 사항

-

<br>

## ⚠️ Issue Number

- #4  #20 

<br><br>
