### PR TITLE
feat/page-detail-reservation : 예매할 때, 이메일 전송 및 DB 업데이트로 인한 toast 로딩 적용

### DIFF
--- a/src/apis/postReservation.ts
+++ b/src/apis/postReservation.ts
@@ -10,7 +10,8 @@ interface PostReservationParamType {
 
 const postReservation = async (data: PostReservationParamType) => {
   try {
-    await axios.post("/api/confirm", data);
+    const result = await axios.post("/api/confirm", data);
+    return result.data;
   } catch (err) {
     throw "서버 요청 실패";
   }

--- a/src/components/detail/ReservationForm/ReservationForm.tsx
+++ b/src/components/detail/ReservationForm/ReservationForm.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { toast } from "react-toastify";
 import { Button, CheckBox, InputField, InputFieldGroup } from "@/components/common";
 import useInputs from "@/hooks/useInputs";
@@ -37,6 +38,8 @@ const ReservationForm: React.FC<PropsType> = ({ showInfo, userInfo, goToPaymentS
   const [phone1, phone2, phone3] = phone_number.split("-");
   const decodedNotice = new TextDecoder().decode(base64ToBytes(notice));
 
+  const [btnDisabled, setBtnDisabled] = useState(false);
+
   const [form, onChange] = useInputs<UserReservationInputsType>({
     show_times_id: date_time[0].id,
     is_receive_email: false,
@@ -58,12 +61,27 @@ const ReservationForm: React.FC<PropsType> = ({ showInfo, userInfo, goToPaymentS
       return;
     }
 
+    setBtnDisabled(true);
+    const toastId = toast.loading("예매 진행 중...");
     try {
       await postReservation(result);
+      toast.update(toastId, {
+        render: "예매 성공하였습니다. 마이페이지에서 확인해주세요",
+        type: toast.TYPE.SUCCESS,
+        isLoading: false,
+        autoClose: 2000,
+      });
+      setBtnDisabled(false);
       setOpenModal({ state: false, type: "" });
-      toast("예매 성공하였습니다. 마이페이지에서 확인해주세요");
     } catch (err) {
       // 예매실패
+      toast.update(toastId, {
+        render: "예매 실패",
+        type: toast.TYPE.ERROR,
+        isLoading: false,
+        autoClose: 2000,
+      });
+      setBtnDisabled(false);
     }
   };
 
@@ -120,7 +138,7 @@ const ReservationForm: React.FC<PropsType> = ({ showInfo, userInfo, goToPaymentS
         </div>
       </form>
 
-      <Button type="submit" form="reservation">
+      <Button type="submit" form="reservation" disabled={btnDisabled}>
         예매하기
       </Button>
     </>

--- a/src/components/detail/ReservationForm/ReservationForm.tsx
+++ b/src/components/detail/ReservationForm/ReservationForm.tsx
@@ -64,15 +64,25 @@ const ReservationForm: React.FC<PropsType> = ({ showInfo, userInfo, goToPaymentS
     setBtnDisabled(true);
     const toastId = toast.loading("예매 진행 중...");
     try {
-      await postReservation(result);
-      toast.update(toastId, {
-        render: "예매 성공하였습니다. 마이페이지에서 확인해주세요",
-        type: toast.TYPE.SUCCESS,
-        isLoading: false,
-        autoClose: 2000,
-      });
-      setBtnDisabled(false);
-      setOpenModal({ state: false, type: "" });
+      const res = await postReservation(result);
+      if (res.ok) {
+        toast.update(toastId, {
+          render: "예매 성공하였습니다. 마이페이지에서 확인해주세요",
+          type: toast.TYPE.SUCCESS,
+          isLoading: false,
+          autoClose: 2000,
+        });
+        setBtnDisabled(false);
+        setOpenModal({ state: false, type: "" });
+      } else {
+        toast.update(toastId, {
+          render: res.message,
+          type: toast.TYPE.ERROR,
+          isLoading: false,
+          autoClose: 2000,
+        });
+        setBtnDisabled(false);
+      }
     } catch (err) {
       // 예매실패
       toast.update(toastId, {


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [x] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

![예약 로딩 토스트](https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/84d9506c-80c7-4aec-932a-0437580ec34f)

<br>

## 🌟 전달 사항

- 헤드 카운트가 0일 때랑 본인이 이미 예약한 것이면 막아주는 기능 넣어줘요
- 그리고 db에 회차 같은 것들이 2개 씩 찍혔는데, 업로드할 때나 수정할 때 발생하는 오류인지 봐주세요 백엔드 문제라면 말해주세욤

<br>

## ⚠️ Issue Number

- #61 

<br><br>
