### PR TITLE
feat/page-mypage-show-manage: 관리자 마이 페이지에서 게시글, 예매 리스트 값 없을 때 보여줄 화면 추가

### DIFF
--- a/src/components/layouts/Header/Header.tsx
+++ b/src/components/layouts/Header/Header.tsx
@@ -19,7 +19,7 @@ const Header = () => {
   const isInMyPage = useMemo(() => location.pathname.includes("/mypage"), [location.pathname]);
 
   useEffect(() => {
-    setIsMyPageNavbarShow(false);
+    handleClose();
   }, [location.pathname]);
 
   const handleOpen = () => {

--- a/src/pages/Mypage/admin/PostManage/PostManagePage.module.css
+++ b/src/pages/Mypage/admin/PostManage/PostManagePage.module.css
@@ -1,4 +1,4 @@
-.container {
+.list {
   box-sizing: border-box;
   width: 100%;
   height: 60vh;
@@ -6,11 +6,6 @@
   border: 1px solid var(--gray300-color);
   border-radius: 5px;
   background-color: var(--gray100-color);
-}
-
-.list {
-  box-sizing: border-box;
-  height: 100%;
   overflow-y: auto;
 }
 

--- a/src/pages/Mypage/admin/PostManage/PostManagePage.tsx
+++ b/src/pages/Mypage/admin/PostManage/PostManagePage.tsx
@@ -5,7 +5,7 @@ import { toast } from "react-toastify";
 import { useModalStore } from "@/stores/useModalStore";
 import { deleteReviewAdmin, getMyShowList, getReviews } from "@/apis";
 import getElapsedTime from "@/utils/getElapsedTime";
-import { Button, Modal, DeleteButton } from "@/components/common";
+import { Button, Modal, DeleteButton, NullField } from "@/components/common";
 import { ReviewDeleteParamType, ReviewType } from "@/types";
 import LikeIcon from "@/assets/like.svg?react";
 import CommentIcon from "@/assets/comment.svg?react";
@@ -67,9 +67,9 @@ const PostManagePage = () => {
 
   return (
     <>
-      <div className={styles["container"]}>
-        <ul className={cx("list", "gray-scrollbar")}>
-          {showList.map((item) => (
+      <ul className={cx("list", "gray-scrollbar")}>
+        {showList.length ? (
+          showList.map((item) => (
             <li className={cx("list-row", "list-item")} key={item.id}>
               <Link to={`/detail/${item.id}`} className={styles["list-row-left"]}>
                 <h3 className={cx("list-item__title", "ellipsis-multi")}>{item.title}</h3>
@@ -95,9 +95,11 @@ const PostManagePage = () => {
                 </Button>
               </div>
             </li>
-          ))}
-        </ul>
-      </div>
+          ))
+        ) : (
+          <NullField text1="아직 등록된 게시글이 없어요!" text2="" />
+        )}
+      </ul>
       <Button style={{ fontSize: "0.75rem", width: "fit-content", marginLeft: "auto" }} onClick={() => navigate("./upload")}>
         게시글 업로드
       </Button>
@@ -124,7 +126,7 @@ const PostManagePage = () => {
                   ))}
                 </ul>
               ) : (
-                <p>댓글이 없습니다</p>
+                <NullField text1="아직 후기/방명록이 없어요!" text2="" />
               )}
             </>
           )}

--- a/src/pages/Mypage/admin/ReservationManage/ReservationManagePage.tsx
+++ b/src/pages/Mypage/admin/ReservationManage/ReservationManagePage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useModalStore } from "@/stores/useModalStore";
-import { Button, Modal } from "@/components/common";
+import { Button, Modal, NullField } from "@/components/common";
 import { ReservationListModal } from "@/components/mypage";
 import { getAdminReservationList } from "@/apis/";
 import styles from "./ReservationManagePage.module.css";
@@ -32,19 +32,23 @@ const ReservationManagePage = () => {
   return (
     <>
       <ul className={cx("list-container", "gray-scrollbar")}>
-        {data.map((item, index) => (
-          <li key={index} className={styles["list-item"]}>
-            <div>
-              <h3 className={cx("list-item__title", "ellipsis-multi")}>{item.title}</h3>
-              <p className={styles["list-item__date"]}>
-                {item.start_date} ~ {item.end_date}
-              </p>
-            </div>
-            <Button reverseColor={true} onClick={handleClickDetailBtn(item.id, item.title)}>
-              예매 현황
-            </Button>
-          </li>
-        ))}
+        {data.length ? (
+          data.map((item, index) => (
+            <li key={index} className={styles["list-item"]}>
+              <div>
+                <h3 className={cx("list-item__title", "ellipsis-multi")}>{item.title}</h3>
+                <p className={styles["list-item__date"]}>
+                  {item.start_date} ~ {item.end_date}
+                </p>
+              </div>
+              <Button reverseColor={true} onClick={handleClickDetailBtn(item.id, item.title)}>
+                예매 현황
+              </Button>
+            </li>
+          ))
+        ) : (
+          <NullField text1="예매가 필요한 게시글이 없어요!" text2="BETA의 예매 서비스를 이용해 보세요" />
+        )}
       </ul>
 
       {openModal.state && openModal.type === "list" && (


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [x] 기능 추가 : NullField 컴포넌트 적용
- [x] 마크업 & 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

<br>

## 🌟 전달 사항

- 마이페이지에서 햄버거 메뉴가 사라질 때 스크롤 auto로 변경되지 않았던거 수정했습니다

<br>

## ⚠️ Issue Number

- #15 
- #45 

<br><br>
