### PR TITLE
feat/page-detail-reservation: 예매 try catch문 리팩토링 및 회차 선택안했을 때 toast 알람 띄우기

### DIFF
--- a/src/apis/postReservation.ts
+++ b/src/apis/postReservation.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 
 interface PostReservationParamType {
   orderId?: string;
@@ -7,13 +7,26 @@ interface PostReservationParamType {
   show_times_id: number;
   is_receive_email: 1 | 0;
 }
+interface ConfirmResponseType {
+  ok: boolean;
+  message: string;
+}
 
-const postReservation = async (data: PostReservationParamType) => {
+const postReservation = async (body: PostReservationParamType) => {
   try {
-    const result = await axios.post("/api/confirm", data);
-    return result.data;
+    const { data } = await axios.post<ConfirmResponseType>("/api/confirm", body);
+
+    if (!data.ok) {
+      throw new Error(data.message);
+    }
   } catch (err) {
-    throw "서버 요청 실패";
+    const error = err as AxiosError;
+    if (error.response?.status) {
+      const data = error.response.data as { message: string };
+      throw new Error(data.message);
+    } else {
+      throw new Error(error.message);
+    }
   }
 };
 

--- a/src/components/common/RadioButtonGroup/RadioButtonGroup.module.css
+++ b/src/components/common/RadioButtonGroup/RadioButtonGroup.module.css
@@ -33,3 +33,14 @@
 .fieldset span {
   vertical-align: middle;
 }
+
+.fieldset input:disabled + span {
+  color: var(--gray200-color);
+  text-decoration: line-through;
+}
+
+.fieldset input:disabled + span::after {
+  content: "예약마감";
+  display: inline-block;
+  margin-left: 0.625rem;
+}

--- a/src/components/common/RadioButtonGroup/RadioButtonGroup.module.css
+++ b/src/components/common/RadioButtonGroup/RadioButtonGroup.module.css
@@ -40,7 +40,7 @@
 }
 
 .fieldset input:disabled + span::after {
-  content: "예약마감";
+  content: "예매마감";
   display: inline-block;
   margin-left: 0.625rem;
 }

--- a/src/components/detail/ReservationForm/ReservationForm.tsx
+++ b/src/components/detail/ReservationForm/ReservationForm.tsx
@@ -119,7 +119,7 @@ const ReservationForm: React.FC<PropsType> = ({ showInfo, userInfo, goToPaymentS
         </div>
 
         <div className={styles["show-reservation-user-info"]}>
-          <h2>예약자 정보</h2>
+          <h2>예매자 정보</h2>
           <InputField type="text" name="name" value={user_name} readOnly>
             이름
           </InputField>
@@ -127,7 +127,7 @@ const ReservationForm: React.FC<PropsType> = ({ showInfo, userInfo, goToPaymentS
           <InputFieldGroup type="email" name="email" values={{ email1, email2 }} userType="user" readOnly />
 
           <CheckBox inputId="이메일받기" name="is_receive_email" checked={!!form.is_receive_email} onChange={onChange}>
-            예약 완료 이메일 전송 동의
+            예매 완료 이메일 전송 동의
           </CheckBox>
         </div>
       </form>

--- a/src/components/detail/ReservationForm/ReservationForm.tsx
+++ b/src/components/detail/ReservationForm/ReservationForm.tsx
@@ -60,7 +60,12 @@ const ReservationForm: React.FC<PropsType> = ({ showInfo, userInfo, goToPaymentS
       await postReservation(result);
 
       toast.update(toastId, {
-        render: "예매 성공하였습니다. 마이페이지에서 확인해주세요",
+        render: (
+          <p>
+            예매 성공하였습니다. <br />
+            마이페이지에서 확인하세요.
+          </p>
+        ),
         type: toast.TYPE.SUCCESS,
         isLoading: false,
         autoClose: 2000,


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [x] 기능 추가 : 회차 선택안했을 때 toast 알람 띄우기
- [ ] 마크업 & 스타일 :
- [x] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용
- 예약 마감 RadioInput 스타일링 (RadioInput 클릭 못하게)
- 예매 try catch문 리팩토링
- 회차 선택안했을 때 toast 알람 띄우기
![ezgif-1-eb2191b220](https://github.com/FESP-TEAM-1/beta-frontend/assets/75666099/dd4ad29a-1b74-4a06-aeb6-2878987bb909)



<br>

## 🌟 전달 사항

-

<br>

## ⚠️ Issue Number

- #4 
- #61 

<br><br>
