### PR TITLE
bfm/common: TicketCard main_image_color 없을 때 리팩토링

### DIFF
--- a/src/components/common/TicketCard/TicketCard.tsx
+++ b/src/components/common/TicketCard/TicketCard.tsx
@@ -19,7 +19,7 @@ const TicketCard: React.FC<PropsType> = ({ item }) => {
           <img src={`${import.meta.env.VITE_APP_IMAGE_DOMAIN}${item.main_image_url}`} alt="" />
         </div>
 
-        <div className={styles["card__info"]} style={{ color: getTxtColorByBgColor(item.main_image_color || "") }}>
+        <div className={styles["card__info"]} style={{ color: getTxtColorByBgColor(item.main_image_color) }}>
           <h3 className={cx("ellipsis-multi", "card__info__title")} style={{ wordBreak: "normal" }}>
             {item.title}
           </h3>

--- a/src/utils/getTxtColorByBgColor.ts
+++ b/src/utils/getTxtColorByBgColor.ts
@@ -1,5 +1,9 @@
-const getTxtColorByBgColor = (hexColor: string | null) => {
-  if (!hexColor) return "black";
+const getTxtColorByBgColor = (hexColor: string | null | undefined) => {
+  const isColorEmpty = hexColor === "undefined" || hexColor === null || hexColor === undefined;
+
+  if (isColorEmpty) {
+    return "black";
+  }
 
   const c = hexColor.substring(1);
   const rgb = parseInt(c, 16);


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [ ] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [x] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

- TicketCard main_image_color 없을 때 기본 글자색깔 검정색 나오게 구현 

<br>

## 🌟 전달 사항
<img width="545" alt="image" src="https://github.com/FESP-TEAM-1/beta-frontend/assets/75666099/7659cf89-c09a-4beb-acef-4025c41b6a56">

- 혹시나 useColor 가 제대로 작동안해서 undefined됐는데 텍스트 컬러가 흰색이면 안되니깐 로직 수정했습니다.
- 원래 처리했었는데 안되길래 보니깐 undefined가 string으로 오더라구요? 그래서 "undefined"로 올때도 텍스트 컬러가 블랙으로 바뀌도록 구현했습니다


<br>

## ⚠️ Issue Number

- #4 

<br><br>
