### PR TITLE
refactor/page-login : Resize 커스텀 훅 생성 및 로그인 페이지 zoom 적용

### DIFF
--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -1,5 +1,5 @@
 import usePreventScroll from "./usePreventScroll";
 import useFilterSlide from "./useFilterSlide";
+import useHandleWidthResize from "./useHandleWidthResize";
 
-export { usePreventScroll, useFilterSlide };
-
+export { usePreventScroll, useFilterSlide, useHandleWidthResize };

--- a/src/hooks/useHandleWidthResize.tsx
+++ b/src/hooks/useHandleWidthResize.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+
+const useHandleResize = (maxWidth: number, setZoom: React.Dispatch<React.SetStateAction<number>>) => {
+  const handleResize = () => {
+    const width = window.innerWidth;
+    const newZoom = width < maxWidth ? width / maxWidth : 1;
+    setZoom(newZoom);
+  };
+
+  useEffect(() => {
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [maxWidth, setZoom]);
+};
+
+export default useHandleResize;

--- a/src/pages/Login/LoginPage.module.css
+++ b/src/pages/Login/LoginPage.module.css
@@ -1,7 +1,7 @@
 .login-main {
   display: flex;
   flex-direction: column;
-  width: 34.375rem;
+  max-width: 34.375rem;
   height: 25.5rem;
   padding: 0 2rem;
   position: relative;

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -5,15 +5,19 @@ import { SignForm, Button, InputField } from "@/components/common";
 import { patchUserLogin } from "@/apis/patchUserLogin";
 import { useLoginStore } from "@/stores/useLoginStore";
 import betaLogo from "@/assets/beta-logo.png";
+import { useHandleWidthResize } from "@/hooks";
 import styles from "./LoginPage.module.css";
 
 const LoginPage = () => {
   const [id, setId] = useState("");
   const [password, setPassword] = useState("");
   const [userType, setUserType] = useState<"user" | "admin">("user");
+  const [zoom, setZoom] = useState(1);
   const { setUserState } = useLoginStore();
   const navigate = useNavigate();
   const { state } = useLocation();
+
+  useHandleWidthResize(625, setZoom);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -38,7 +42,7 @@ const LoginPage = () => {
   };
 
   return (
-    <main className={styles["login-main"]}>
+    <main className={styles["login-main"]} style={{ zoom: zoom }}>
       <div className={styles["logo-div"]}>
         <img src={betaLogo} alt="로고 이미지" className={styles["logo-img"]} onClick={moveToMain} />
       </div>


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [x] 기능 추가 : Resize 커스텀 훅 추가
- [ ] 마크업 & 스타일 :
- [x] 리팩토링 : 로그인 페이지 Resize 적용
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

| <img src="https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/b1540899-b9db-4c5d-abed-a3d54272137f" width="400" /> | <img src="https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/dcb90856-6613-4840-a368-9e4af47559b1" width="400" height="500" /> |
| :--------: | :--------: |
|  width가 고정으로 있어서 반응형 적용이 되지 않음  | max-width로 수정하면 크기가 너무 작게 나옴 | 

<br>

- 너비를 유지하면서 크기만 축소시키기 위해 zoom을 적용
<img src="https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/632bb644-5330-42e7-a0f7-2f24c26eb525" width="500" />


<br>

## 🌟 전달 사항

<br>

## ⚠️ Issue Number

- #3 

<br><br>
