### PR TITLE
refactor/page-mypage-profile : 마이페이지 프로필 Resize zoom 적용

### DIFF
--- a/src/pages/Mypage/Mypage.module.css
+++ b/src/pages/Mypage/Mypage.module.css
@@ -36,3 +36,15 @@
     position: absolute;
   }
 }
+
+@media (max-width: 375px) {
+  .title-hidden {
+    font-size: 1rem;
+  }
+}
+
+@media (max-width: 320px) {
+  .title-hidden {
+    font-size: 0.8rem;
+  }
+}

--- a/src/pages/Mypage/ProfilePage/ProfilePage.tsx
+++ b/src/pages/Mypage/ProfilePage/ProfilePage.tsx
@@ -8,6 +8,7 @@ import { isEmailCheck } from "@/utils/emailCheck";
 import { useLoginStore } from "@/stores/useLoginStore";
 import { ProfileBodyType } from "@/types/SignupBodyType";
 import { getUserProfile, postSignupAPI, putProfileUpdate } from "@/apis";
+import { useHandleWidthResize } from "@/hooks";
 import styles from "./ProfilePage.module.css";
 
 interface BirthdateGenderType {
@@ -25,6 +26,7 @@ interface idPasswordCheck {
 const cx = classNames.bind(styles);
 
 const ProfilePage = () => {
+  const [zoom, setZoom] = useState(1);
   const { userState } = useLoginStore();
   const [password, setPassword] = useState<idPasswordCheck>({ value: "", isConfirm: false });
   const [checkPassword, setCheckPassword] = useState<idPasswordCheck>({ value: "", isConfirm: false });
@@ -50,6 +52,8 @@ const ProfilePage = () => {
     queryKey: ["userProfile"],
     queryFn: () => getUserProfile(userState.login_id),
   });
+
+  useHandleWidthResize(625, setZoom);
 
   useEffect(() => {
     if (data) {
@@ -211,7 +215,7 @@ const ProfilePage = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className={styles["profile-section-form"]}>
+    <form onSubmit={handleSubmit} className={styles["profile-section-form"]} style={{ transform: `scale(${zoom})` }}>
       <div className={styles["profile-section-form-group"]}>
         <InputField required type="text" value={data.login_id} readOnly>
           아이디

--- a/src/pages/Mypage/ProfilePage/ProfilePage.tsx
+++ b/src/pages/Mypage/ProfilePage/ProfilePage.tsx
@@ -215,7 +215,7 @@ const ProfilePage = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className={styles["profile-section-form"]} style={{ transform: `scale(${zoom})` }}>
+    <form onSubmit={handleSubmit} className={styles["profile-section-form"]} style={{ zoom: zoom }}>
       <div className={styles["profile-section-form-group"]}>
         <InputField required type="text" value={data.login_id} readOnly>
           아이디


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [x] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

- 현재 요소들이 너무 작게 표시되고 깨지는 경우도 있음
<img src="https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/04bdcee1-9082-44a4-97e3-0abadb553509" width="400" height="700" />

<br><br>

- 너비를 유지하면서 크기만 축소 시키기 위해 zoom을 적용
- 또한, 화면의 크기가 줄어 들어도 "프로필 설정" 이라는 글씨가 너무 커서 375, 320일 때 font-size 수정
<img src="https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/f467835a-1a17-4420-85f4-d82ec6bd3fdb" width="500" />

<br>

## 🌟 전달 사항

- 마찬가지로 login 부분 pr 먼저 머지 해주세요~

<br>

## ⚠️ Issue Number

- #45 

<br><br>
