### PR TITLE
refactor/page-main : 전시/공연 페이지 필터링 부분 리팩토링

### DIFF
--- a/src/components/common/Filters/Filters.module.css
+++ b/src/components/common/Filters/Filters.module.css
@@ -100,3 +100,22 @@
   background: url("@/assets/arrow.svg") no-repeat center / 2rem;
   transform: rotate(-180deg);
 }
+
+@media screen and (max-width: 768px) {
+  .date-select-container.show {
+    padding-left: 0;
+  }
+}
+
+@media screen and (max-width: 500px) {
+  .date-select-container.show {
+    padding-left: 0;
+    flex-wrap: wrap;
+  }
+}
+
+@media screen and (max-width: 320px) {
+  .date-input {
+    font-size: 0.775rem;
+  }
+}

--- a/src/components/common/Filters/Filters.tsx
+++ b/src/components/common/Filters/Filters.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { toast } from "react-toastify";
-import { Button, FilterButton, SelectBox } from "@/components/common";
+import { FilterButton, SelectBox } from "@/components/common";
 import { ShowFilterRequestType } from "@/types";
 import { getTodayStringDate, getStringDate } from "@/utils";
 import { useFilterSlide } from "@/hooks";

--- a/src/components/common/Filters/Filters.tsx
+++ b/src/components/common/Filters/Filters.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { toast } from "react-toastify";
-import { FilterButton, SelectBox } from "@/components/common";
+import { Button, FilterButton, SelectBox } from "@/components/common";
 import { ShowFilterRequestType } from "@/types";
 import { getTodayStringDate, getStringDate } from "@/utils";
 import { useFilterSlide } from "@/hooks";
@@ -59,7 +59,12 @@ const Filters: React.FC<PropsType> = ({ filterRequest, setFilterRequest }) => {
     date: "오늘",
     location: "전체",
     category: "전체",
-    progress: "전체",
+    progress: "진행중",
+  });
+
+  const [selectDate, setSelectDate] = useState({
+    start_date: todayString,
+    end_date: todayString,
   });
 
   const isEndDateAfterStartDate = (startDate: string, endDate: string) => {
@@ -73,12 +78,15 @@ const Filters: React.FC<PropsType> = ({ filterRequest, setFilterRequest }) => {
 
   const handleChangeDate = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target as HTMLInputElement;
-    if (name === "end_date" && !isEndDateAfterStartDate(filterRequest.start_date, value)) {
+    setSelectDate((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleChangeDateSubmit = () => {
+    if (!isEndDateAfterStartDate(selectDate.start_date, selectDate.end_date)) {
       toast.warn("시작날짜보다 끝나는 날짜가 앞설 수 없습니다. 날짜를 다시 설정해주세요.");
       return;
     }
-
-    setFilterRequest((prev) => ({ ...prev, [name]: value }));
+    setFilterRequest((prev) => ({ ...prev, start_date: selectDate.start_date, end_date: selectDate.end_date }));
   };
 
   // 서버에 보낼 start_date와 end_date를 set하는 함수
@@ -96,7 +104,7 @@ const Filters: React.FC<PropsType> = ({ filterRequest, setFilterRequest }) => {
       default:
         break;
     }
-    setFilterRequest((prev) => ({ ...prev, end_date: dateString }));
+    setFilterRequest((prev) => ({ ...prev, start_date: dateString }));
   };
 
   // progress를 all, 1, 2, 3으로 set하는 함수
@@ -147,12 +155,15 @@ const Filters: React.FC<PropsType> = ({ filterRequest, setFilterRequest }) => {
       <div className={cx("date-select-container", filter.date === "직접선택" && "show")}>
         <label>
           <p className="a11y-hidden">시작일</p>
-          <input className={styles["date-input"]} type="date" name="start_date" value={filterRequest.start_date} onChange={handleChangeDate} />
+          <input className={styles["date-input"]} type="date" name="start_date" value={selectDate.start_date} onChange={handleChangeDate} />
         </label>
         <label>
           <p className={"a11y-hidden"}>종료일</p>
-          <input className={styles["date-input"]} type="date" name="end_date" value={filterRequest.end_date} onChange={handleChangeDate} />
+          <input className={styles["date-input"]} type="date" name="end_date" value={selectDate.end_date} onChange={handleChangeDate} />
         </label>
+        <Button onClick={handleChangeDateSubmit} style={{ borderRadius: "24px", width: "80px", height: "40px", padding: "0" }}>
+          적용
+        </Button>
       </div>
 
       <div className={styles["filter-row"]}>

--- a/src/components/common/Filters/Filters.tsx
+++ b/src/components/common/Filters/Filters.tsx
@@ -82,18 +82,17 @@ const Filters: React.FC<PropsType> = ({ filterRequest, setFilterRequest }) => {
   };
 
   const handleChangeDateSubmit = () => {
-    if (!isEndDateAfterStartDate(selectDate.start_date, selectDate.end_date)) {
+    const { start_date, end_date } = selectDate;
+    if (!isEndDateAfterStartDate(start_date, end_date)) {
       toast.warn("시작날짜보다 끝나는 날짜가 앞설 수 없습니다. 날짜를 다시 설정해주세요.");
       return;
     }
-    setFilterRequest((prev) => ({ ...prev, start_date: selectDate.start_date, end_date: selectDate.end_date }));
+    setFilterRequest((prev) => ({ ...prev, start_date: start_date, end_date: end_date }));
   };
 
   // 서버에 보낼 start_date와 end_date를 set하는 함수
   const dateSetFunc = (value: string) => {
     let dateString = todayString;
-    setFilterRequest((prev) => ({ ...prev, start_date: dateString }));
-
     switch (value) {
       case dates[1]:
         ({ dateString } = getStringDate(todayYear, todayMonth, todayDay + 7));
@@ -161,9 +160,9 @@ const Filters: React.FC<PropsType> = ({ filterRequest, setFilterRequest }) => {
           <p className={"a11y-hidden"}>종료일</p>
           <input className={styles["date-input"]} type="date" name="end_date" value={selectDate.end_date} onChange={handleChangeDate} />
         </label>
-        <Button onClick={handleChangeDateSubmit} style={{ borderRadius: "24px", width: "80px", height: "40px", padding: "0" }}>
+        <FilterButton onClick={handleChangeDateSubmit} selected={true}>
           적용
-        </Button>
+        </FilterButton>
       </div>
 
       <div className={styles["filter-row"]}>

--- a/src/pages/MainConcert/MainConcertPage.tsx
+++ b/src/pages/MainConcert/MainConcertPage.tsx
@@ -12,7 +12,7 @@ const MainConcertPage = () => {
     start_date: todayString,
     end_date: todayString,
     location: "all",
-    progress: "all",
+    progress: "1",
     category: "all",
   });
 

--- a/src/pages/MainExhibition/MainExhibitionPage.tsx
+++ b/src/pages/MainExhibition/MainExhibitionPage.tsx
@@ -10,7 +10,7 @@ const MainExhibitionPage = () => {
     start_date: todayString,
     end_date: todayString,
     location: "all",
-    progress: "all",
+    progress: "1",
   });
 
   return (


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [ ] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [x] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

<img src="https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/332abb21-738e-4978-bd4c-0c5121d4c2f7" width="600" />

<img src="https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/eafc46e5-857d-417e-9912-df87fde2eb5d" width="400" />

<br />
<br />

진행 여부 => "전체"만 날짜 필터링과 연관 없음
"전체"일 경우는 날짜 상관없이 모든 게시글을 출력
"진행중", "진행예정", "종료"는 아래의 글 참고해주세요.

오늘을 "2024-01-21"이라고 예를 들어서

"진행중" 
- "오늘"은 말 그대로 게시글의 시작, 종료 날짜 사이에 오늘 날짜가 포함되어 있는 애들을 출력
- "+7일"은 게시글의 시작, 종료 날짜 사이에 일주일 뒤인 2024-01-28을 포함하고 있으면 출력
- "+2주"도 마찬가지로 게시글의 시작, 종료 날짜 사이에 2주 뒤인 2024-02-04을 포함하고 있으면 출력
예를 들어 게시글의 기간이 (2023-12-22 ~ 2024-01-25) 이렇게라면 "오늘"은 출력되고 "+7일" 부터는 출력되지 않음 (날짜가 일주일 이후부터는 종료된 게시글이기 때문에)

"진행예정"
- "오늘" 날짜가 게시글의 시작 날짜보다 작은 경우 출력
- "+7일" 날짜 (2024-01-28)가 게시글의 시작 날짜보다 작은 경우 출력
- "+2주" 날짜 (2024-02-04)가 게시글의 시작 날짜보다 작은 경우 출력
예를 들어 게시글의 기간이 (2024-02-01 ~ 2024-02-20) 이라면 "오늘", "+7일"은 출력되고 "+2주" 부터 출력되지 않음

"종료"
- "오늘" 날짜가 게시글의 종료 날짜보다 큰 경우 출력
- "+7일" 날짜 (2024-01-28)가 게시글의 종료 날짜보다 큰 경우 출력
- "+2주" 날짜 (2024-02-04)가 게시글의 종료 날짜보다 큰 경우 출력
예를 들어 게시글의 기간이 (2023-12-22 ~ 2024-01-25) 이렇게라면 "오늘"은 출력되지 않지만 "+7일" 부터는 출력

<hr>

- 날짜 버튼 클릭 시 종료 날짜를 바꾸는 게 아닌 시작 날짜를 바꾸도록 변경
- 페이지 접근할 때, "진행중"을 디폴트 값으로 설정
- 날짜 필터링에서 "직접선택" 부분에 적용 버튼 추가
 
<br>

## 🌟 전달 사항

- 이슈 번호 4번인데 5번으로 했어요... ㅎㅎ
- 백엔드 부분도 수정했기 때문에 pull 받아서 진행해주시면 됩니다.

<br>

## ⚠️ Issue Number

- #4 #20 

<br><br>
