### PR TITLE
refactor/error-handling : toast 에러 메시지 한 번에 출력 되는 현상 수정 및 로그인 세션 만료 처리

### DIFF
--- a/src/hooks/useApiError.tsx
+++ b/src/hooks/useApiError.tsx
@@ -1,17 +1,21 @@
 import axios from "axios";
 import { useCallback } from "react";
 import { toast } from "react-toastify";
+import { useLoginStore } from "@/stores";
 
 interface ErrorResponse {
   ok: boolean;
   message: string;
+  errorCode?: string;
 }
 
 const useApiError = () => {
+  const { setUserState } = useLoginStore();
   const handleError = useCallback((error: unknown) => {
     // 얘는 잘 안 먹힘
     if (!navigator.onLine) {
       toast.error("인터넷 연결이 끊겼습니다. 연결 상태를 확인해주세요.");
+      toast.clearWaitingQueue();
       return;
     }
 
@@ -20,26 +24,40 @@ const useApiError = () => {
         const httpStatus = error.response?.status;
         const errorResponse = error.response?.data as ErrorResponse;
         const httpMessage = errorResponse.message;
+        const httpErrorCode = errorResponse.errorCode || null;
 
         // 에러 핸들러를 실행하기 전에 httpStatus가 유효한지 확인합니다.
         const handle = httpStatus ? statusHandlers[httpStatus] : statusHandlers.default;
-        handle(httpMessage);
+        handle(httpMessage, httpErrorCode);
+        toast.clearWaitingQueue();
+        return;
       } else {
         toast.error("서버 연결이 원활하지 않습니다.");
+        toast.clearWaitingQueue();
+        return;
       }
     } else {
       toast.error("네트워크 연결 오류 또는 기타 오류가 발생했습니다.");
+      toast.clearWaitingQueue();
+      return;
     }
   }, []);
 
-  return { handleError };
-};
+  const statusHandlers: { [key: number]: (msg: string, errorCode: string | null) => void; default: (msg: string) => void } = {
+    400: (msg: string) => toast.error(msg),
+    401: (msg: string, errorCode) => {
+      if (errorCode === "NOT_LOGGED_IN") {
+        setUserState({ isLogin: false, login_id: "", user_name: "", user_role: "" });
+        toast.error("로그인 세션이 만료가 되었습니다. 다시 로그인 해주세요.");
+      } else {
+        toast.error(`${msg}`);
+      }
+    },
+    500: () => toast.error("서버 오류가 발생했습니다."),
+    default: () => toast.error("서버에서 알 수 없는 오류가 발생했습니다."),
+  };
 
-const statusHandlers: { [key: number]: (msg: string) => void; default: (msg: string) => void } = {
-  400: (msg: string) => toast.error(msg),
-  401: (msg: string) => toast.error(`인증 에러 : ${msg}`),
-  500: () => toast.error("서버 오류가 발생했습니다."),
-  default: () => toast.error("서버에서 알 수 없는 오류가 발생했습니다."),
+  return { handleError };
 };
 
 export default useApiError;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,6 +23,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       pauseOnHover={true}
       draggable={true}
       theme="light"
+      limit={1}
     />
   </>,
   // </React.StrictMode>,


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [ ] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [x] 리팩토링 : 로그인 세션 만료 처리
- [ ] 문서 수정 :
- [x] 버그 수정 : toast 에러 메시지 여러 개 뜨는 현상 수정
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

 <img src="https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/0774abd2-b08e-40b2-a189-6a3d7b254c34" width='500' />

1. toast 에러 메시지 여러 개 뜨는 현상 수정

- 위와 같이 메인 페이지에서 총 3개의 API 요청을 진행하는데, 서버가 꺼져 있거나 문제가 발생할 경우 API는 3개의 에러를 발생
- useApiError.tsx에서 axios 에러 발생 시 toast 에러 알림 메시지를 띄우는데, 한 번에 3개의 에러 메시지가 나오는 문제 생김

<br>

- Tanstack Query는 기본적으로 retry를 3번 하게 되어 있음
- 각 API의 retry가 실패할 때마다 onError로 가게 되고 useApiError에서 에러 핸들링을 처리하여 toast에 에러 메시지가 쌓이게 됨
- 최종적으로 3번의 retry가 모두 끝나고 요청이 완전히 실패하게 되면 그동안 쌓인 toast 에러 메시지들이 한 번에 출력 되게 됨
- toast의 limit을 1로 설정 후 clearWaitingQueue() 함수를 사용하여 대기 메시지를 전부 삭제 (이슈 #127 참고)

<br>

<img src="https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/cf7f4cec-d273-49b4-92ab-331e2a836023" width='500' />

2. 로그인 세션 만료 처리
- 로그인 토큰이 만료 됐을 경우 Zustand의 유저 전역 상태 값을 초기화
- 헤더는 전역 상태 값에 따라 로그인 여부를 체크하기 때문에 유저 값 초기화 시 로그인 버튼으로 바뀜

<br>

## 🌟 전달 사항

- 백엔드 살짝 바꾼 게 있어서 미치는 영향은 없긴 한데 그냥 pull 받아 주세요~
- 지금 서버가 꺼져서 에러 발생 시 Network Error라고 화면에 보여지게 되는데 이거 ErrorBoundary로 처리해야 될 것 같슴다 공부를... 

<br>

## ⚠️ Issue Number

- #119 #127 

<br><br>
