### PR TITLE
fix/page-mypage-show-update: S3 이미지에 대해 CORS 오류 해결을 위한 쿼리 파라미터 추가

### DIFF
--- a/src/components/mypage/admin/ImageInputSection/ImageInputSection.tsx
+++ b/src/components/mypage/admin/ImageInputSection/ImageInputSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import ImgUploadIcon from "@/assets/ImgUploadIcon.svg?react";
 import { DeleteButton } from "@/components/common";
 import styles from "./ImageInputSection.module.css";
@@ -12,6 +12,8 @@ interface PropsType {
 const ImageInputSection: React.FC<PropsType> = ({ imgExistingUrls, setImgExistingUrls }) => {
   const { resetImageFiles, addImageFiles, removeImageFiles } = useImageFileStore();
   const { imagePreviewUrls, resetImagePreviewUrls, addImagePreviewUrls, removeImagePreviewUrls } = useImagePreviewUrlStore();
+
+  const timestamp = useRef(new Date().getTime()).current;
 
   useEffect(() => {
     return () => {
@@ -53,7 +55,7 @@ const ImageInputSection: React.FC<PropsType> = ({ imgExistingUrls, setImgExistin
             imgExistingUrls.map((image) => (
               <li key={image}>
                 <div className={styles["img-cover"]}>
-                  <img src={import.meta.env.VITE_APP_IMAGE_DOMAIN + image} alt="" />
+                  <img src={import.meta.env.VITE_APP_IMAGE_DOMAIN + image + "?" + timestamp} alt="" />
                   <DeleteButton spanHidden="해당 이미지 삭제" onClick={() => handleRemoveExistingImage(image)} forImage />
                 </div>
               </li>

--- a/src/hooks/usePickMainImageColor.tsx
+++ b/src/hooks/usePickMainImageColor.tsx
@@ -1,10 +1,14 @@
 import { useImagePreviewUrlStore } from "@/stores";
 import { useColor } from "color-thief-react";
+import { useRef } from "react";
 
 const usePickMainImageColor = (imageExistingUrl = "") => {
   const { imagePreviewUrls } = useImagePreviewUrlStore();
+
+  const timestamp = useRef(new Date().getTime()).current;
+
   const { data: main_image_color } = useColor(
-    imageExistingUrl ? `${import.meta.env.VITE_APP_IMAGE_DOMAIN + imageExistingUrl}` : imagePreviewUrls[0],
+    imageExistingUrl ? `${import.meta.env.VITE_APP_IMAGE_DOMAIN + imageExistingUrl + "?" + timestamp}` : imagePreviewUrls[0],
     "hex",
     {
       crossOrigin: "anonymous",

--- a/src/utils/appendUpdateImageToFormData.ts
+++ b/src/utils/appendUpdateImageToFormData.ts
@@ -11,7 +11,7 @@ const appendUpdateImageToFormData = async (formData: FormData, imageFiles: File[
     // 기존 메인 이미지가 변경되면 (그대로면 보내지 않음)
     if (imgExistingUrls[0] !== originMainUrl) {
       // imgExistingUrls[0]을 file로 변환하고 jpeg 리사이즈해서 보내기
-      const mainImageFile = await convertUrlToFile(import.meta.env.VITE_APP_IMAGE_DOMAIN + imgExistingUrls[0]);
+      const mainImageFile = await convertUrlToFile(import.meta.env.VITE_APP_IMAGE_DOMAIN + imgExistingUrls[0] + "?" + new Date().getTime());
       const blobString = URL.createObjectURL(mainImageFile);
       const jpeg = await reduceImageSize(blobString);
       const finalMainImageFile = new File([jpeg], imgExistingUrls[0], { type: "image/jpeg" });


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [ ] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

### 캐시 우회
- 이미지 태그의 `src` 속성에 타임 스탬프를 쿼리 파라미터로 추가 (_아래의 이미지 참고_)
- 각 요청의 URL을 고유하게 만들어 브라우저가 새로운 요청으로 인식하게 하여 캐시를 우회

![image](https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/34a762f8-8245-4b32-8b41-04cbce005f06)

### 무한 리렌더링
- 캐시 우회까지는 맞는데, React에서는 URL이 계속 변경이 되어 새로운 값으로 인식하고 컴포넌트를 무한 리렌더링 하는 문제 발생
- 이를 방지하기 위해 `useRef` Hook을 사용하여 타임 스탬프 값을 넣고 값이 변경되어도 리렌더링이 발생하지 않음

```
const timestamp = useRef(new Date().getTime()).current;

{imgExistingUrls &&
  imgExistingUrls.map((image) => (
    <li key={image}>
      <div className={styles["img-cover"]}>
        <img src={import.meta.env.VITE_APP_IMAGE_DOMAIN + image + "?" + timestamp} alt="" />
        <DeleteButton spanHidden="해당 이미지 삭제" onClick={() => handleRemoveExistingImage(image)} forImage />
      </div>
    </li>
  ))}
```
<br>

## 🌟 전달 사항

- 이슈에 더 자세한 내용 있습니다. (#135 )
- 백엔드에 배너 이미지 최신 코드와 옛날 코드 충돌로 인한 문제도 있어서 백엔드 pull 받아 주시면 됩니다.
- 백엔드 환경변수를 수정했습니다. (.env.development, .env.production)
   - 기존 .env 파일은 삭제하고 2개의 파일을 추가해주세요.
   -  디스코드 환경 변수 백엔드 글 참고해주시면 됩니다.

<br>

## ⚠️ Issue Number

- #135 

<br><br>
