### PR TITLE
refactor/payment : 결제 부분 프론트에서 백엔드로 로직 변경 및 결제 취소 기능 추가

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -8,7 +8,9 @@ import getShowReservationInfo from "./reservation/getShowReservationInfo";
 import getUserReservationList from "./reservation/getUserReservationList";
 import getAdminReservationList from "./reservation/getAdminReservationList";
 import getAdminReservationDetail from "./reservation/getAdminReservationDetail";
+import postPayVerification from "./reservation/postPayVerification";
 import postReservation from "./reservation/postReservation";
+import postTossConfirm from "./reservation/postTossConfirm";
 import deleteReservation from "./reservation/deleteReservation";
 
 import getReviewList from "./review/getReviewList";
@@ -47,7 +49,9 @@ export {
   getUserReservationList,
   getAdminReservationList,
   getAdminReservationDetail,
+  postPayVerification,
   postReservation,
+  postTossConfirm,
   deleteReservation,
   getReviewList,
   getUserReviewList,

--- a/src/apis/reservation/postPayVerification.ts
+++ b/src/apis/reservation/postPayVerification.ts
@@ -1,0 +1,20 @@
+import axios from "axios";
+import { ErrorResponseType } from "@/types";
+
+interface PostPayVerificationParamType {
+  show_id: number;
+  show_times_id: number;
+  amount?: string;
+}
+
+/*
+  - 로그인 여부
+  - 예매 가능 여부
+  - 서버 오류 등
+*/
+const postPayVerification = async (body: PostPayVerificationParamType) => {
+  const { data } = await axios.post<ErrorResponseType>(`/api/payVerification`, body);
+  return data;
+};
+
+export default postPayVerification;

--- a/src/apis/reservation/postReservation.ts
+++ b/src/apis/reservation/postReservation.ts
@@ -1,33 +1,15 @@
-import axios, { AxiosError } from "axios";
+import axios from "axios";
+import { ErrorResponseType } from "@/types";
 
 interface PostReservationParamType {
-  orderId?: string;
-  amount?: string;
   show_id: number;
   show_times_id: number;
   is_receive_email: 1 | 0;
 }
-interface ConfirmResponseType {
-  ok: boolean;
-  message: string;
-}
 
 const postReservation = async (body: PostReservationParamType) => {
-  try {
-    const { data } = await axios.post<ConfirmResponseType>(`/api/confirm`, body);
-
-    if (!data.ok) {
-      throw new Error(data.message);
-    }
-  } catch (err) {
-    const error = err as AxiosError;
-    if (error.response?.status) {
-      const data = error.response.data as { message: string };
-      throw new Error(data.message);
-    } else {
-      throw new Error(error.message);
-    }
-  }
+  const { data } = await axios.post<ErrorResponseType>(`/api/confirm`, body);
+  return data;
 };
 
 export default postReservation;

--- a/src/apis/reservation/postTossConfirm.ts
+++ b/src/apis/reservation/postTossConfirm.ts
@@ -1,0 +1,18 @@
+import axios from "axios";
+import { ErrorResponseType } from "@/types";
+
+interface PostTossConfirmParamType {
+  orderId: string;
+  amount: string;
+  paymentKey: string;
+  show_id: number;
+  show_times_id: number;
+  is_receive_email: 1 | 0;
+}
+
+const postTossConfirm = async (body: PostTossConfirmParamType) => {
+  const { data } = await axios.post<ErrorResponseType>(`/api/tossConfirm`, body);
+  return data;
+};
+
+export default postTossConfirm;

--- a/src/pages/PayFail/PayFailPage.tsx
+++ b/src/pages/PayFail/PayFailPage.tsx
@@ -1,5 +1,6 @@
 import { useReservationFormStore } from "@/stores";
 import { Link, useSearchParams } from "react-router-dom";
+import "@/components/detail/ReservationPayment/style.css";
 
 const PayFailPage = () => {
   const { reservationForm } = useReservationFormStore();

--- a/src/types/errorResponse.ts
+++ b/src/types/errorResponse.ts
@@ -1,0 +1,4 @@
+export interface ErrorResponseType {
+  ok: boolean;
+  message: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,7 @@ import { SignupBodyType, ProfileBodyType } from "./signupBodyType";
 import { StoryResponseType, StoryType } from "./storyType";
 import { UserReservationFormType, UserReservationInputsType } from "./userReservationFormType";
 import { ResponseUserReservationInfoType, UserReservationInfoType } from "./userReservationInfoType";
+import { ErrorResponseType } from "./errorResponse";
 
 export {
   type ShowResponseType,
@@ -40,4 +41,5 @@ export {
   type ReviewPatchParamType,
   type ResponseUserReservationInfoType,
   type UserReservationInfoType,
+  type ErrorResponseType,
 };


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [x] 기능 추가 : 예매 취소 시 결제 취소 기능 추가 (단, 예전에 예매한 것들은 해당 안 됨)
- [ ] 마크업 & 스타일 :
- [x] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [x] 도와주세요 : 예매 실패 보면 예매 성공이 됐다가 0.5초 뒤에 실패 페이지로 넘어가는데 어떻게 할까요?
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

1. 무료 예매

| <img src="https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/b0e0aa9b-8e93-4804-af73-dc6c9cf22b32" width="700" /> | <img src="https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/84acba2b-0e1c-46b4-bd3d-0d369ce22865" width="400" /> | 
| :--------: | :--------: |
|  회차 날짜가 이미 지난 경우  |  무료 예매 결제 완료 후 바로 쿼리 무효화로 재 예매 막기  |

2. 유료 예매

| ![ezgif com-speed](https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/028f03a4-cc2f-4009-a0c5-87b31bb3ee36) | ![ezgif com-speed (1)](https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/92dc114f-5759-429f-bde4-0307c421d641) | 
| :--------: | :--------: |
|  예매 성공  |  예매 실패  |

3. 예매 취소

![ezgif com-video-to-gif-converter (3)](https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/7d6dc4b3-f803-4cfe-998b-66c6d9437b0f)

<br>

## 🌟 전달 사항

- 프론트에서 토스페이먼츠 결제 로직을 백엔드로 옮겼습니다.
- 백엔드 풀 받아주세요! 근데 백엔드는 브랜치를 따로 파지 않아서 이거 머지 해야 예매 될듯합니다.
- 하나 걸리는 건 예매 실패 보면 예매 성공이 됐다가 0.5초 뒤에 실패 페이지로 넘어가는데 어떻게 할까요?

<br>

## ⚠️ Issue Number

- #61 

<br><br>
