### PR TITLE
refactor/page-mypage-delete : 마이페이지 삭제 시 confirm 띄우기

### DIFF
--- a/src/components/mypage/user/ReviewItem/ReviewItem.tsx
+++ b/src/components/mypage/user/ReviewItem/ReviewItem.tsx
@@ -20,7 +20,10 @@ const ReviewItem: React.FC<ReviewType> = (item) => {
   });
 
   const handleClickDeleteButton = (review_id: number, show_id: number) => {
-    deleteMutate({ review_id, show_id });
+    if (confirm("정말 삭제하시겠습니까?")) {
+      deleteMutate({ review_id, show_id });
+    }
+    return;
   };
 
   const elapsedTime = getElapsedTime(item.created_at);

--- a/src/components/mypage/user/StoryItem/StoryItem.tsx
+++ b/src/components/mypage/user/StoryItem/StoryItem.tsx
@@ -27,8 +27,11 @@ const StoryItem: React.FC<StoryType> = ({ id, login_id, story_image_url, story_c
 
   const handleClickDeleteStory = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    const story_id = e.currentTarget.name;
-    deleteMutate({ story_id, login_id });
+    if (window.confirm("정말 스토리를 삭제 하시겠습니까?")) {
+      const story_id = e.currentTarget.name;
+      deleteMutate({ story_id, login_id });
+      return;
+    }
   };
 
   return (


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [ ] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [x] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

마이페이지 리뷰 삭제
<img width="779" alt="image" src="https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/9d66452b-8f2e-411b-83bd-1f1efd725803">

마이페이지 스토리 삭제
<img width="755" alt="image" src="https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/762b6096-a9b4-40fb-900f-a972a265d869">


<br>

## 🌟 전달 사항

<br>

## ⚠️ Issue Number

- #45 

<br><br>
