### PR TITLE
refactor/page-detail-reservation: 예매 관련 리팩토링

### DIFF
--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -16,6 +16,7 @@ import usePickMainImageColor from "./usePickMainImageColor";
 import useInterval from "./useInterval";
 import useDeleteReviewQuery from "./useDeleteReviewQuery";
 import useImgLazyLoading from "./useImgLazyLoading";
+import useReservationAlert from "./useReservationAlert";
 
 export {
   useAuth,
@@ -36,4 +37,5 @@ export {
   useNetworkOffline,
   useInterval,
   useImgLazyLoading,
+  useReservationAlert,
 };

--- a/src/hooks/useReservationAlert.tsx
+++ b/src/hooks/useReservationAlert.tsx
@@ -1,0 +1,37 @@
+import { toast, Id } from "react-toastify";
+
+const useReservationAlert = () => {
+  const showReservationAlert = (toastId: Id) => {
+    toast.update(toastId, {
+      render: "예매 진행 중...",
+      type: toast.TYPE.INFO,
+      isLoading: true,
+    });
+  };
+  const showReservationSuccessAlert = (toastId: Id) => {
+    toast.update(toastId, {
+      render: (
+        <p>
+          예매 성공하였습니다. <br />
+          마이페이지에서 확인하세요.
+        </p>
+      ),
+      type: toast.TYPE.SUCCESS,
+      isLoading: false,
+      autoClose: 2000,
+    });
+  };
+
+  const showReservationFailAlert = (toastId: Id, errorMessage: string) => {
+    toast.update(toastId, {
+      render: errorMessage,
+      type: toast.TYPE.ERROR,
+      isLoading: false,
+      autoClose: 2000,
+    });
+  };
+
+  return { showReservationAlert, showReservationSuccessAlert, showReservationFailAlert };
+};
+
+export default useReservationAlert;


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [ ] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [x] 리팩토링 :
- [ ] 문서 수정 :
- [ ] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

- toast alert 코드가 길어서 custom hook으로 빼서 사용해보았습니다.
- submitReservation에서 무료예매일때의 로직을 submitFreeReservation 함수로 분리하여 submitReservation 함수에서 호출하는 방식으로 변경했습니다.

<br>

## 🌟 전달 사항

-

<br>

## ⚠️ Issue Number

- #61 

<br><br>
