### PR TITLE
fix/page-mypage : 프로필 페이지 select box 값 변경 오류 및 좋아요 관리 페이지 캐싱 값만 가져오는 오류 수정

### DIFF
--- a/src/components/common/InputFieldGroup/InputFieldGroup.tsx
+++ b/src/components/common/InputFieldGroup/InputFieldGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useState, SetStateAction } from "react";
+import React, { useState, SetStateAction, useEffect } from "react";
 import { BirthdateGenderValues, EmailValues, PhoneValues, PropsType } from "./InputFieldGroupType";
 import { getYears, getMonths, getDays } from "@/utils";
 import styles from "./InputFieldGroup.module.css";
@@ -37,8 +37,18 @@ const InputFieldGroup: React.FC<PropsType> = ({ type, values, setValues, userTyp
     }
   };
 
+  const emailOptions = ["gmail.com", "naver.com", "daum.net", "직접 입력"];
   const [isReadOnly, setIsReadOnly] = useState(true);
   const [selectedDomain, setSelectedDomain] = useState("gmail.com");
+
+  useEffect(() => {
+    if (type === "email" && "email2" in values) {
+      const emailDomain = values.email2;
+      const newDomain = emailOptions.includes(emailDomain) ? emailDomain : "직접 입력";
+      setSelectedDomain(newDomain);
+      setIsReadOnly(newDomain !== "직접 입력");
+    }
+  }, [values, type]);
 
   switch (type) {
     case "phone":
@@ -124,8 +134,6 @@ const InputFieldGroup: React.FC<PropsType> = ({ type, values, setValues, userTyp
     }
 
     case "email": {
-      const emailOptions = ["gmail.com", "naver.com", "daum.net", "직접 입력"];
-
       const handleEmailDomainChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const { value } = e.target;
         setSelectedDomain(value);

--- a/src/components/mypage/user/ListItemList/LikeItemList.tsx
+++ b/src/components/mypage/user/ListItemList/LikeItemList.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { NullField } from "@/components/common";
 import { LikeItem } from "@/components/mypage";
-import { ShowType } from "@/types";
+import { getUserLikeList } from "@/apis";
 import styles from "./LikeItemList.module.css";
 import classNames from "classnames/bind";
 
@@ -13,10 +13,18 @@ interface PropsType {
 }
 
 const LikeItemList = React.memo<PropsType>(({ selectedCategory }) => {
-  const queryClient = useQueryClient();
-  const userLikeList = queryClient.getQueryData<ShowType[]>(["userLikeList"]) || [];
+  const {
+    data: filteredList,
+    status,
+    error,
+  } = useQuery({
+    queryKey: ["userLikeList"],
+    queryFn: () => getUserLikeList(),
+    select: (data) => data.filter((data) => data.show_type === selectedCategory),
+  });
 
-  const filteredList = userLikeList.filter((data) => data.show_type === selectedCategory);
+  if (status === "pending") return <h1>loading...</h1>;
+  if (status === "error") return <h1>{error.message}</h1>;
 
   if (filteredList.length === 0) {
     return (

--- a/src/pages/Mypage/user/LikeManage/LikeManagePage.tsx
+++ b/src/pages/Mypage/user/LikeManage/LikeManagePage.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { getUserLikeList } from "@/apis";
+import { useQueryClient } from "@tanstack/react-query";
 import { FilterButton } from "@/components/common";
 import { LikeItemList } from "@/components/mypage";
 import styles from "./LikeManagePage.module.css";
@@ -16,14 +15,6 @@ const LikeManagePage = () => {
     setSelectedCategory(value!);
     queryClient.invalidateQueries({ queryKey: ["userLikeList"] });
   };
-
-  const { status, error } = useQuery({
-    queryKey: ["userLikeList"],
-    queryFn: () => getUserLikeList(),
-  });
-
-  if (status === "pending") return <h1>loading...</h1>;
-  if (status === "error") return <h1>{error.message}</h1>;
 
   return (
     <div className={styles["filter-row"]}>


### PR DESCRIPTION
### 🤚 잠깐!

- [x] PR 제목 형식 확인 [`브랜치명 : 작업 내용`]
- [x] 이슈 등록 확인
- [x] 라벨 등록 확인

## ✏️ PR 요약

- [ ] 기능 추가 :
- [ ] 마크업 & 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 :
- [ ] 도와주세요 :
- [ ] 개발 환경 세팅 :

<br>

## 💡 상세 작업 내용

프로필 페이지에서 저장된 이메일 도메인이 아닌 기본 값인 "google.com"이 select box에 표시 되는 오류 수정
<img width="431" alt="image" src="https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/d292be1d-400e-46cf-9929-5c49c2ab7d5e">

<br>

상세 페이지에서 좋아요를 눌러도 좋아요 관리 페이지에서는 캐싱 된 값만 가져오기 때문에 새로고침 하지 않는 이상 업데이트가 되지 않는 오류 수정
<img src="https://github.com/FESP-TEAM-1/beta-frontend/assets/78673090/361bd45e-6e19-40a4-9c05-2aacb398ee3d" width="500" />

<br>

## 🌟 전달 사항

- 좋아요 관리 페이지는 구조를 좀 바꿨습니다. managePage에서 useQuery로 데이터를 가져오던 것을 LikeList 컴포넌트에서 가져오는 방식으로 바꿨습니다.
- 뭐가 가장 나은 방법인지는 잘 모르겠는데, 다양한 방법이 있고 캐싱된 데이터를 가져오는 것이 제일 나은 방법인데 상세 페이지와 좋아요 관리 페이지가 서로 다른 쿼리 키를 사용하고 있어서 캐시 초기화를 하기 힘들어서 애매한 것 같슴다
- 더 좋은 방법이 있으면 말해주세요~

<br>

## ⚠️ Issue Number

- #4 #45 

<br><br>
